### PR TITLE
Update 08-Fingerprint_Web_Application_Framework.md

### DIFF
--- a/latest/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md
+++ b/latest/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.md
@@ -295,7 +295,7 @@ RewriteCond %{REQUEST_URI} /wp-admin/$
 RewriteRule $ /http://your_website [R=404,L]
 ```
 
-However, these are not the only ways to restrict access. In order to automate this process, certain framework-specific plugins exist. One example for WordPress is [StealthLogin](https://wordpress.org/plugins/stealth-login-page).
+However, these are not the only ways to restrict access. In order to automate this process, certain framework-specific plugins exist.
 
 ### Additional Approaches
 


### PR DESCRIPTION
The WP "Stealth Login Page" plugin is not available anymore since April 15th, 2020. https://wordpress.org/plugins/stealth-login-page/. 

Check the details here: https://wordpress.org/plugins/stealth-login-page/