### PR TITLE
v41 and stable tweaks

### DIFF
--- a/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
+++ b/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
@@ -51,10 +51,12 @@ def page():
 
 This code snippet is vulnerable to XSS but it is also vulnerable to SSTI. Using the following as a payload in the `name` parameter:
 
+{% raw %}
 ```bash
 $ curl -g 'http://www.target.com/page?name={{7*7}}'
 Hello 49!
 ```
+{% endraw %}
 
 ## How to Test
 
@@ -70,11 +72,13 @@ The first step in testing SSTI in plaintext context is to construct common templ
 
 Common template expression examples:
 
+{% raw %}
 ```html
 a{{bar}}b
 a{{7*7}}
 {var} ${var} {{var}} <%var%> [% var %]
 ```
+{% endraw %}
 
 In this step an extensive [template expression test strings/payloads list](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Template%20Injection) is recommended.
 

--- a/tab_downloads.md
+++ b/tab_downloads.md
@@ -17,6 +17,8 @@ View the always-current stable version at [stable](stable/).
 
 [Version 4.1](v41/) serves as a post-migration stable version under the new GitHub repository workflow.
 
+[Download the v4.1 PDF](https://github.com/OWASP/wstg/releases/download/v4.1/wstg-v4.1.pdf) here.
+
 ## [Version 4.0] - 2014-09-17
 
 [Download the v4 PDF](assets/archive/OWASP_Testing_Guide_v4.pdf) here.

--- a/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
+++ b/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
@@ -51,10 +51,12 @@ def page():
 
 This code snippet is vulnerable to XSS but it is also vulnerable to SSTI. Using the following as a payload in the `name` parameter:
 
+{% raw %}
 ```bash
 $ curl -g 'http://www.target.com/page?name={{7*7}}'
 Hello 49!
 ```
+{% endraw %}
 
 ## How to Test
 
@@ -70,11 +72,13 @@ The first step in testing SSTI in plaintext context is to construct common templ
 
 Common template expression examples:
 
+{% raw %}
 ```html
 a{{bar}}b
 a{{7*7}}
 {var} ${var} {{var}} <%var%> [% var %]
 ```
+{% endraw %}
 
 In this step an extensive [template expression test strings/payloads list](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Template%20Injection) is recommended.
 


### PR DESCRIPTION
- Add v4.1 PDF to download tab.
- Add raw code tags to SSTI pages so that they render properly for v41 and stable.

```text
    Liquid Warning: Liquid syntax error (line 48): Unexpected character
* in "{{7*7}}" in v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
    Liquid Warning: Liquid syntax error (line 68): Unexpected character
* in "{{7*7}}" in v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection.md
```

Ref: https://jekyllrb.com/docs/liquid/tags/

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>