### PR TITLE
Fixed typo in node named "<user>"

### DIFF
--- a/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.md
+++ b/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.md
@@ -19,7 +19,7 @@ This section describes practical examples of XML Injection. First, an XML style 
 
 ## How to Test
 
-Let's suppose there is a web application using an XML style communication in order to perform user registration. This is done by creating and adding a new `user>`node in an `xmlDb` file.
+Let's suppose there is a web application using an XML style communication in order to perform user registration. This is done by creating and adding a new `<user>`node in an `xmlDb` file.
 
 Let's suppose the xmlDB file is like the following:
 


### PR DESCRIPTION
Line 22 was missing the opening bracket for the <user> tag.  Fixed by adding the opening bracket.