### PR TITLE
Update A-Testing_Tools_Resource.md - fix link SSLyze

### DIFF
--- a/stable/6-Appendix/A-Testing_Tools_Resource.md
+++ b/stable/6-Appendix/A-Testing_Tools_Resource.md
@@ -67,7 +67,7 @@ tags: WSTG
 #### Testing SSL
 
 - [O-Saft](https://github.com/OWASP/O-Saft)
-- [sslyze](https://github.com/iSECPartners/sslyze)
+- [SSLyze](https://github.com/nabla-c0d3/sslyze)
 - [TestSSLServer](https://www.bolet.org/TestSSLServer/)
 - [SSLScan](https://sourceforge.net/projects/sslscan/)
 - [SSLScan windows](https://github.com/rbsec/sslscan/releases)


### PR DESCRIPTION
Link to SSLyze went to old repo of https://github.com/iSECPartners/sslyze
As per that repo readme development moved to https://github.com/nabla-c0d3/sslyze
Also corrected capitalization of SSLyze