### PR TITLE
Update list of vulnapps

### DIFF
--- a/v42/6-Appendix/B-Suggested_Reading.md
+++ b/v42/6-Appendix/B-Suggested_Reading.md
@@ -72,10 +72,8 @@ tags: WSTG
 ## Deliberately Insecure Web Applications
 
 - [OWASP Vulnerable Web Applications Directory Project](https://owasp.org/www-project-vulnerable-web-applications-directory/)
-- [BadStore](https://www.vulnhub.com/entry/badstore-123,41)
 - [Damn Vulnerable Web App](http://www.dvwa.co.uk/)
+- [OWASP Juice Shop](https://owasp-juice.shop)
+- [OWASP WebGoat](https://owasp.org/www-project-webgoat/)
+- [Xtreme Vulnerable Web Application](https://github.com/s4n7h0/xvwa)
 - [Mutillidae](https://www.irongeek.com/i.php?page=mutillidae/mutillidae-deliberately-vulnerable-php-owasp-top-10)
-- [Stanford SecuriBench](https://suif.stanford.edu/~livshits/securibench/)
-- [Vicnum](https://sourceforge.net/projects/vicnum/)
-- [WebGoat](https://owasp.org/www-project-webgoat/)
-- [WebMaven (better known as Buggy Bank)](https://www.mavensecurity.com/about/webmaven)


### PR DESCRIPTION
Rationale: VWAD as directory first in list. Then in order of GitHub stars apps from VWAD which had recent (2020) updates and were not all from same technology stack. Bonus condition for OWASP projects was to have a migrated website to appear.