### PR TITLE
Add twitter feed in side bar

### DIFF
--- a/leaders.md
+++ b/leaders.md
@@ -3,3 +3,5 @@
 * [Elie Saad](https://twitter.com/7hunderSon)
 * [Rick Mitchell](mailto:kingthorin@gmail.com)
 * Matteo Meucci
+
+{% include twitter-feed.html twitter="owasp_wstg" %}


### PR DESCRIPTION
Use new twitter feed include to add owasp_wstg twitter feed embeds to the side bar

See also: https://github.com/OWASP/www--site-theme/pull/77

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>