### PR TITLE
improve: Don't include file extension in links & update slack invite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 remote_theme: "owasp/www--site-theme@main"
+permalink: :path
 #override default star and watch buttons
 code_user: OWASP
 code_repo: wstg

--- a/info.md
+++ b/info.md
@@ -17,7 +17,7 @@
 
 ### Social
 
-* [Join OWASP Slack](https://owasp-slack.herokuapp.com/)
+* [Join OWASP Slack](https://owasp.org/slack/invite)
 * Channel: [#testing-guide](https://app.slack.com/client/T04T40NHX/CJ2QDHLRJ)
 * Twitter: [@owasp_wstg](https://twitter.com/owasp_wstg)
 


### PR DESCRIPTION
The _config.yml permalink change was tested locally.
The slack invite should have happened a while ago.

Related to https://github.com/OWASP/wstg/pull/763

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>