### PR TITLE
sidebar: Drop twitter include

### DIFF
--- a/leaders.md
+++ b/leaders.md
@@ -2,5 +2,3 @@
 
 * [Elie Saad](mailto:elie.saad@owasp.org)
 * [Rick Mitchell](mailto:kingthorin@gmail.com)
-
-{% include twitter-feed.html twitter="owasp_wstg" %}


### PR DESCRIPTION
It no longer displays content due to Elon Musk changes, so let's drop it.
