### PR TITLE
Update 05.3-Testing_for_SQL_Server.md

### DIFF
--- a/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
+++ b/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server.md
@@ -226,7 +226,7 @@ Other options for out of band attacks are described in [Sample 4 above](#Example
 
 #### Trial and Error
 
-Alternatively, one may play lucky. That is the attacker may assume that there is a blind or out-of-band SQL injection vulnerability in a the web application. He will then select an attack vector (e.g., a web entry), [use fuzz vectors](../../6-Appendix/C-Fuzz_Vectors.md) against this channel and watch the response. For example, if the web application is looking for a book using a query
+Alternatively, one may play lucky. That is the attacker may assume that there is a blind or out-of-band SQL injection vulnerability in the web application. He will then select an attack vector (e.g., a web entry), [use fuzz vectors](../../6-Appendix/C-Fuzz_Vectors.md) against this channel and watch the response. For example, if the web application is looking for a book using a query
 
 ```sql
 select * from books where title="text entered by the user"


### PR DESCRIPTION
typo in Blind SQL Injection Attack : 
"a the" should be "the"

:warning: Have you followed the [contributions guideance](https://owasp.org/www-project-web-security-testing-guide/#contributions)? Content PRs should generally be made against the the [source repo `OWASP/wstg`](https://github.com/OWASP/wstg).
