### PR TITLE
Update 05-Testing_for_SQL_Injection.md

### DIFF
--- a/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
+++ b/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.md
@@ -289,11 +289,11 @@ Which is exploitable through the methods seen previously. What we want to obtain
 
 Through such functions, we will execute our tests on the first character and, when we have discovered the value, we will pass to the second and so on, until we will have discovered the entire value. The tests will take advantage of the function SUBSTRING, in order to select only one character at a time (selecting a single character means to impose the length parameter to 1), and the function ASCII, in order to obtain the ASCII value, so that we can do numerical comparison. The results of the comparison will be done with all the values of the ASCII table, until the right value is found. As an example, we will use the following value for `Id`:
 
-`$Id=1' AND ASCII(SUBSTRING(username,1,1))=97 AND '1'='1`
+`$Id=1' OR ASCII(SUBSTRING(username,1,1))=97 AND '1'='1`
 
 That creates the following query (from now on, we will call it "inferential query"):
 
-`SELECT field1, field2, field3 FROM Users WHERE Id='1' AND ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`
+`SELECT field1, field2, field3 FROM Users WHERE Id='1' OR ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`
 
 The previous example returns a result if and only if the first character of the field username is equal to the ASCII value 97. If we get a false value, then we increase the index of the ASCII table from 97 to 98 and we repeat the request. If instead we obtain a true value, we set to zero the index of the ASCII table and we analyze the next character, modifying the parameters of the SUBSTRING function. The problem is to understand in which way we can distinguish tests returning a true value from those that return false. To do this, we create a query that always returns false. This is possible by using the following value for `Id`:
 
@@ -309,11 +309,11 @@ In the previous discussion, we haven't dealt with the problem of determining the
 
 We will insert the following value for the field `Id`:
 
-`$Id=1' AND LENGTH(username)=N AND '1' = '1`
+`$Id=1' OR LENGTH(username)=N AND '1' = '1`
 
 Where N is the number of characters that we have analyzed up to now (not counting the null value). The query will be:
 
-`SELECT field1, field2, field3 FROM Users WHERE Id='1' AND LENGTH(username)=N AND '1' = '1'`
+`SELECT field1, field2, field3 FROM Users WHERE Id='1' OR LENGTH(username)=N AND '1' = '1'`
 
 The query returns either true or false. If we obtain true, then we have completed the inference and, therefore, we know the value of the parameter. If we obtain false, this means that the null character is present in the value of the parameter, and we must continue to analyze the next parameter until we find another null value.
 


### PR DESCRIPTION
### Fix boolean logic error for inference methods

The current inferential query will only work in cases where the Id value actually equals 1. In blind SQL cases this value is likely not known.
`SELECT field1, field2, field3 FROM Users WHERE Id='1' AND ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`

Changing the first AND to an OR will ensure the inferential query executes regardless of the Id value.
`SELECT field1, field2, field3 FROM Users WHERE Id='1' OR ASCII(SUBSTRING(username,1,1))=97 AND '1'='1'`