### PR TITLE
edited logical typo

### DIFF
--- a/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging.md
+++ b/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging.md
@@ -48,7 +48,7 @@ function handler(event) {
 
 ### Origin Security
 
-The origin is made up of a scheme, host name, and port. It uniquely identifies the domain sending or receiving the message, and does not include the path or the fragment part of the URL. For instance, `https://example.com` will be considered different from `https://example.com` because the schema of the former is `https`, while the latter is `http`. This also applies to web servers running in the same domain but on different ports.
+The origin is made up of a scheme, host name, and port. It uniquely identifies the domain sending or receiving the message, and does not include the path or the fragment part of the URL. For instance, `https://example.com` will be considered different from `http://example.com` because the schema of the former is `https`, while the latter is `http`. This also applies to web servers running in the same domain but on different ports.
 
 ## Test Objectives
 


### PR DESCRIPTION
>...because the schema of the former is https, while the latter is http

Implies the second example is using http - I edited the text accordingly