### PR TITLE
Fix typo in Testing for Default Credentials section

### DIFF
--- a/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
+++ b/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.md
@@ -68,7 +68,7 @@ The passwords may be based on:
 - A time-based algorithm.
 - A weak pseudo-random number generator (PRNG).
 
-This type of issue of often difficult to identify from a black-box perspective.
+This type of issue is often difficult to identify from a black-box perspective.
 
 ## Tools
 


### PR DESCRIPTION
Incorrectly had:
of
Instead of
is

:warning: Have you followed the "contributions guideance" - https://owasp.org/www-project-web-security-testing-guide/#contributions

Content PRs should generally be made against the the project repo: "OWASP/wstg" - https://github.com/OWASP/wstg

> [!CAUTION]
> Contributions should only be made in the proper repo against the latest content. Please don't open PRs here for versioned or stable content, they represent point-in-time state.  
