### PR TITLE
feat: match nav filter against title aliases and IDs

### DIFF
--- a/_data/latest.yaml
+++ b/_data/latest.yaml
@@ -59,149 +59,212 @@ docs:
       children:
         - title: '4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage
+          hints: 'wstg-info-01 info-01'
         - title: '4.1.2 Fingerprint Web Server'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server
+          hints: 'wstg-info-02 info-02'
         - title: '4.1.3 Review Webserver Metafiles for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage
+          hints: 'robots robots.txt sitemap sitemap.xml wstg-info-03 info-03'
         - title: '4.1.4 Attack Surface Identification'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/04-Attack_Surface_Identification
+          hints: 'wstg-info-04 info-04'
         - title: '4.1.5 Review Web Page Content for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Web_Page_Content_for_Information_Leakage
+          hints: 'wstg-info-05 info-05'
         - title: '4.1.6 Identify Application Entry Points'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points
+          hints: 'wstg-info-06 info-06'
         - title: '4.1.7 Map Execution Paths Through Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application
+          hints: 'wstg-info-07 info-07'
         - title: '4.1.8 Fingerprint Web Application Framework'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework
+          hints: 'wstg-info-08 info-08'
         - title: '4.1.9 Fingerprint Web Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application
+          hints: 'wstg-info-09 info-09 wstg-info-08 info-08'
         - title: '4.1.10 Map Application Architecture'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture
+          hints: 'wstg-info-10 info-10'
     - title: '4.2 Configuration and Deployment Management Testing'
       url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/README
       children:
         - title: '4.2.1 Test Network Infrastructure Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration
+          hints: 'wstg-conf-01 conf-01'
         - title: '4.2.2 Test Application Platform Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration
+          hints: 'wstg-conf-02 conf-02'
         - title: '4.2.3 Test File Extensions Handling for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information
+          hints: 'wstg-conf-03 conf-03'
         - title: '4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
+          hints: 'wstg-conf-04 conf-04'
         - title: '4.2.5 Enumerate Infrastructure and Application Admin Interfaces'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces
+          hints: 'wstg-conf-05 conf-05'
         - title: '4.2.6 Test HTTP Methods'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods
+          hints: 'wstg-conf-06 conf-06'
         - title: '4.2.7 Test HTTP Strict Transport Security'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security
+          hints: 'hsts headers wstg-conf-07 conf-07'
         - title: '4.2.8 Test RIA Cross Domain Policy'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy
+          hints: 'crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08'
         - title: '4.2.9 Test File Permission'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission
+          hints: 'wstg-conf-09 conf-09'
         - title: '4.2.10 Test for Subdomain Takeover'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover
+          hints: 'wstg-conf-10 conf-10'
         - title: '4.2.11 Test Cloud Storage'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage
+          hints: 's3 bucket blob storage wstg-conf-11 conf-11'
         - title: '4.2.12 Test for Content Security Policy'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy
+          hints: 'csp headers wstg-conf-12 conf-12'
         - title: '4.2.13 Test for Path Confusion'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/13-Test_for_Path_Confusion
+          hints: 'wstg-conf-13 conf-13'
         - title: '4.2.14 Test Other HTTP Security Header Misconfigurations'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/14-Test_Other_HTTP_Security_Header_Misconfigurations
+          hints: 'headers wstg-conf-14 conf-14'
     - title: '4.3 Identity Management Testing'
       url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/README
       children:
         - title: '4.3.1 Test Role Definitions'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions
+          hints: 'wstg-idnt-01 idnt-01'
         - title: '4.3.2 Test User Registration Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process
+          hints: 'wstg-idnt-02 idnt-02'
         - title: '4.3.3 Test Account Provisioning Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process
+          hints: 'wstg-idnt-03 idnt-03'
         - title: '4.3.4 Testing for Account Enumeration and Guessable User Account'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account
+          hints: 'wstg-idnt-04 idnt-04'
         - title: '4.3.5 Testing for Weak or Unenforced Username Policy'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy
+          hints: 'wstg-idnt-05 idnt-05 wstg-idnt-04 idnt-04'
     - title: '4.4 Authentication Testing'
       url: 4-Web_Application_Security_Testing/04-Authentication_Testing/README
       children:
         - title: '4.4.1 Testing for Credentials Transported over an Encrypted Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel
+          hints: 'tls ssl https wstg-athn-01 athn-01 wstg-cryp-03 cryp-03'
         - title: '4.4.2 Testing for Default Credentials'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials
+          hints: 'wstg-athn-02 athn-02'
         - title: '4.4.3 Testing for Weak Lock Out Mechanism'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism
+          hints: 'rate limit bruteforce brute force account lockout wstg-athn-03 athn-03'
         - title: '4.4.4 Testing for Bypassing Authentication Schema'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema
+          hints: 'wstg-athn-04 athn-04'
         - title: '4.4.5 Testing for Vulnerable Remember Password'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password
+          hints: 'wstg-athn-05 athn-05'
         - title: '4.4.6 Testing for Browser Cache Weaknesses'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses
+          hints: 'wstg-athn-06 athn-06'
         - title: '4.4.7 Testing for Weak Authentication Methods'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Authentication_Methods
+          hints: 'wstg-athn-07 athn-07'
         - title: '4.4.8 Testing for Weak Security Question Answer'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer
+          hints: 'wstg-athn-08 athn-08'
         - title: '4.4.9 Testing for Weak Password Change or Reset Functionalities'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities
+          hints: 'wstg-athn-09 athn-09'
         - title: '4.4.10 Testing for Weaker Authentication in Alternative Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel
+          hints: 'wstg-athn-10 athn-10'
         - title: '4.4.11 Testing Multi-Factor Authentication'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/11-Testing_Multi-Factor_Authentication
+          hints: 'mfa 2fa totp wstg-athn-11 athn-11'
     - title: '4.5 Authorization Testing'
       url: 4-Web_Application_Security_Testing/05-Authorization_Testing/README
       children:
         - title: '4.5.1 Testing Directory Traversal File Include'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include
+          hints: 'path traversal dotdot lfi wstg-athz-01 athz-01'
         - title: '4.5.2 Testing for Bypassing Authorization Schema'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema
+          hints: 'wstg-athz-02 athz-02'
         - title: '4.5.3 Testing for Privilege Escalation'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation
+          hints: 'privesc wstg-athz-03 athz-03'
         - title: '4.5.4 Testing for Insecure Direct Object References'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References
+          hints: 'idor wstg-athz-04 athz-04'
         - title: '4.5.5 Testing for OAuth Weaknesses'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/05-Testing_for_OAuth_Weaknesses
+          hints: 'oauth2 wstg-athz-05 athz-05'
           children:
             - title: '4.5.5.1 Testing for OAuth Authorization Server Weaknesses'
               url: 4-Web_Application_Security_Testing/05-Authorization_Testing/05.1-Testing_for_OAuth_Authorization_Server_Weaknesses
+              hints: 'oauth2'
             - title: '4.5.5.2 Testing for OAuth Client Weaknesses'
               url: 4-Web_Application_Security_Testing/05-Authorization_Testing/05.2-Testing_for_OAuth_Client_Weaknesses
+              hints: 'oauth2'
     - title: '4.6 Session Management Testing'
       url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/README
       children:
         - title: '4.6.1 Testing for Session Management Schema'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema
+          hints: 'wstg-sess-01 sess-01'
         - title: '4.6.2 Testing for Cookies Attributes'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes
+          hints: 'cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02'
         - title: '4.6.3 Testing for Session Fixation'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation
+          hints: 'wstg-sess-03 sess-03'
         - title: '4.6.4 Testing for Exposed Session Variables'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables
+          hints: 'wstg-sess-04 sess-04'
         - title: '4.6.5 Testing for Cross Site Request Forgery'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery
+          hints: 'csrf xsrf wstg-sess-05 sess-05'
         - title: '4.6.6 Testing for Logout Functionality'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality
+          hints: 'wstg-sess-06 sess-06'
         - title: '4.6.7 Testing Session Timeout'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout
+          hints: 'wstg-sess-07 sess-07'
         - title: '4.6.8 Testing for Session Puzzling'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling
+          hints: 'wstg-sess-08 sess-08'
         - title: '4.6.9 Testing for Session Hijacking'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking
+          hints: 'wstg-sess-09 sess-09'
         - title: '4.6.10 Testing JSON Web Tokens'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens
+          hints: 'jwt wstg-sess-10 sess-10'
         - title: '4.6.11 Testing for Concurrent Sessions'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/11-Testing_for_Concurrent_Sessions
+          hints: 'wstg-sess-11 sess-11'
     - title: '4.7 Input Validation Testing'
       url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/README
       children:
         - title: '4.7.1 Testing for Reflected Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-01 inpv-01'
         - title: '4.7.2 Testing for Stored Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-02 inpv-02'
         - title: '4.7.3 Testing for HTTP Verb Tampering'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering
+          hints: 'verb tampering wstg-inpv-03 inpv-03 wstg-conf-06 conf-06'
         - title: '4.7.4 Testing for HTTP Parameter Pollution'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
+          hints: 'hpp wstg-inpv-04 inpv-04'
         - title: '4.7.5 Testing for SQL Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection
+          hints: 'sqli wstg-inpv-05 inpv-05'
           children:
             - title: '4.7.5.1 Testing for Oracle'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.1-Testing_for_Oracle
@@ -209,71 +272,97 @@ docs:
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL
             - title: '4.7.5.3 Testing for SQL Server'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server
+              hints: 'mssql sql server'
             - title: '4.7.5.4 Testing PostgreSQL'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.4-Testing_PostgreSQL
             - title: '4.7.5.5 Testing for MS Access'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access
             - title: '4.7.5.6 Testing for NoSQL Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection
+              hints: 'sqli nosqli'
             - title: '4.7.5.7 Testing for ORM Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection
             - title: '4.7.5.8 Testing for Client-side'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.8-Testing_for_Client-side
         - title: '4.7.6 Testing for LDAP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection
+          hints: 'ldapi wstg-inpv-06 inpv-06'
         - title: '4.7.7 Testing for XML Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection
+          hints: 'xxe xmli xml injection wstg-inpv-07 inpv-07'
         - title: '4.7.8 Testing for SSI Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection
+          hints: 'ssi injection wstg-inpv-08 inpv-08'
         - title: '4.7.9 Testing for XPath Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection
+          hints: 'xpathi xml wstg-inpv-09 inpv-09'
         - title: '4.7.10 Testing for IMAP SMTP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection
+          hints: 'email injection wstg-inpv-10 inpv-10'
         - title: '4.7.11 Testing for Code Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11-Testing_for_Code_Injection
+          hints: 'rce wstg-inpv-11 inpv-11'
           children:
             - title: '4.7.11.1 Testing for File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_File_Inclusion
+              hints: 'lfi rfi'
         - title: '4.7.12 Testing for Command Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection
+          hints: 'rce cmdi os command wstg-inpv-12 inpv-12'
         - title: '4.7.13 Testing for Format String Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection
+          hints: 'format string bug wstg-inpv-13 inpv-13'
         - title: '4.7.14 Testing for Incubated Vulnerability'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability
+          hints: 'wstg-inpv-14 inpv-14'
         - title: '4.7.15 Testing for HTTP Response Splitting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Response_Splitting
+          hints: 'crlf response splitting wstg-inpv-15 inpv-15'
         - title: '4.7.16 Testing for HTTP Request Smuggling'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Request_Smuggling
+          hints: 'http smuggling wstg-inpv-16 inpv-16'
         - title: '4.7.17 Testing for Host Header Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
+          hints: 'host header injection headers wstg-inpv-17 inpv-17'
         - title: '4.7.18 Testing for Server-side Template Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection
+          hints: 'ssti wstg-inpv-18 inpv-18'
         - title: '4.7.19 Testing for Server-Side Request Forgery'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery
+          hints: 'ssrf wstg-inpv-19 inpv-19'
         - title: '4.7.20 Testing for Mass Assignment'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/20-Testing_for_Mass_Assignment
+          hints: 'mass assign wstg-inpv-20 inpv-20'
         - title: '4.7.21 Testing for CSV Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/21-Testing_for_CSV_Injection
+          hints: 'formula injection wstg-inpv-21 inpv-21'
         - title: '4.7.22 Testing for Prototype Pollution'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/22-Testing_for_Prototype_Pollution
+          hints: 'pp wstg-inpv-22 inpv-22'
     - title: '4.8 Testing for Error Handling'
       url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/README
       children:
         - title: '4.8.1 Testing for Improper Error Handling'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling
+          hints: 'wstg-errh-01 errh-01'
         - title: '4.8.2 Testing for Stack Traces'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces
+          hints: 'wstg-errh-02 errh-02 wstg-errh-01 errh-01'
     - title: '4.9 Testing for Weak Cryptography'
       url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/README
       children:
         - title: '4.9.1 Testing for Weak Transport Layer Security'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security
+          hints: 'tls ssl https wstg-cryp-01 cryp-01'
         - title: '4.9.2 Testing for Padding Oracle'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle
+          hints: 'padding oracle attack wstg-cryp-02 cryp-02'
         - title: '4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels
+          hints: 'tls ssl https cleartext wstg-cryp-03 cryp-03'
         - title: '4.9.4 Testing for Weak Cryptographic Primitives'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Cryptographic_Primitives
+          hints: 'wstg-cryp-04 cryp-04'
     - title: '4.10 Business Logic Testing'
       url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/README
       children:
@@ -281,60 +370,86 @@ docs:
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic
         - title: '4.10.1 Test Business Logic Data Validation'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation
+          hints: 'wstg-busl-01 busl-01'
         - title: '4.10.2 Test Ability to Forge Requests'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests
+          hints: 'wstg-busl-02 busl-02'
         - title: '4.10.3 Test Integrity Checks'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks
+          hints: 'wstg-busl-03 busl-03'
         - title: '4.10.4 Test for Process Timing'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing
+          hints: 'race condition toctou wstg-busl-04 busl-04'
         - title: '4.10.5 Test Number of Times a Function Can Be Used Limits'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits
+          hints: 'rate limit bruteforce brute force wstg-busl-05 busl-05'
         - title: '4.10.6 Testing for the Circumvention of Work Flows'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows
+          hints: 'wstg-busl-06 busl-06'
         - title: '4.10.7 Test Defenses Against Application Misuse'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse
+          hints: 'wstg-busl-07 busl-07'
         - title: '4.10.8 Test Upload of Unexpected File Types'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types
+          hints: 'wstg-busl-08 busl-08'
         - title: '4.10.9 Test Upload of Malicious Files'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files
+          hints: 'wstg-busl-09 busl-09'
         - title: '4.10.10 Test Payment Functionality'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/10-Test-Payment-Functionality
+          hints: 'wstg-busl-10 busl-10'
     - title: '4.11 Client-side Testing'
       url: 4-Web_Application_Security_Testing/11-Client-side_Testing/README
       children:
         - title: '4.11.1 Testing for DOM-Based Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting
+          hints: 'xss dom xss domxss wstg-clnt-01 clnt-01'
           children:
             - title: '4.11.1.1 Testing for Self DOM Based Cross-Site Scripting'
               url: 4-Web_Application_Security_Testing/11-Client-side_Testing/01.1-Testing_for_Self_DOM_Based_Cross_Site_Scripting
+              hints: 'xss dom xss domxss'
         - title: '4.11.2 Testing for JavaScript Execution'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution
+          hints: 'wstg-clnt-02 clnt-02'
         - title: '4.11.3 Testing for HTML Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection
+          hints: 'wstg-clnt-03 clnt-03'
         - title: '4.11.4 Testing for Client-side URL Redirect'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect
+          hints: 'open redirect wstg-clnt-04 clnt-04'
         - title: '4.11.5 Testing for CSS Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection
+          hints: 'wstg-clnt-05 clnt-05'
         - title: '4.11.6 Testing for Client-side Resource Manipulation'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation
+          hints: 'wstg-clnt-06 clnt-06'
         - title: '4.11.7 Testing Cross Origin Resource Sharing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing
+          hints: 'cors headers wstg-clnt-07 clnt-07'
         - title: '4.11.8 Testing for Cross Site Flashing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing
+          hints: 'wstg-clnt-08 clnt-08'
         - title: '4.11.9 Testing for Clickjacking'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking
+          hints: 'ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09'
         - title: '4.11.10 Testing WebSockets'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets
+          hints: 'ws wstg-clnt-10 clnt-10'
         - title: '4.11.11 Testing Web Messaging'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging
+          hints: 'postmessage post message wstg-clnt-11 clnt-11'
         - title: '4.11.12 Testing Browser Storage'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage
+          hints: 'localstorage sessionstorage wstg-clnt-12 clnt-12'
         - title: '4.11.13 Testing for Cross Site Script Inclusion'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion
+          hints: 'xssi wstg-clnt-13 clnt-13'
         - title: '4.11.14 Testing for Reverse Tabnabbing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/14-Testing_for_Reverse_Tabnabbing
+          hints: 'tabnabbing window.opener wstg-clnt-14 clnt-14'
         - title: '4.11.15 Testing for Client-side Template Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/15-Testing_for_Client-Side_Template_Injection
+          hints: 'csti wstg-clnt-15 clnt-15'
     - title: '4.12 API Testing'
       url: 4-Web_Application_Security_Testing/12-API_Testing/README
       children:
@@ -342,14 +457,19 @@ docs:
           url: 4-Web_Application_Security_Testing/12-API_Testing/00-API_Testing_Overview
         - title: '4.12.1 API Reconnaissance'
           url: 4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance
+          hints: 'wstg-apit-01 apit-01'
         - title: '4.12.2 API Broken Object Level Authorization'
           url: 4-Web_Application_Security_Testing/12-API_Testing/02-API_Broken_Object_Level_Authorization
+          hints: 'bola idor wstg-apit-02 apit-02'
         - title: '4.12.3 Testing for Excessive Data Exposure'
           url: 4-Web_Application_Security_Testing/12-API_Testing/03-Testing_for_Excessive_Data_Exposure
+          hints: 'wstg-apit-03 apit-03'
         - title: '4.12.4 API Broken Function Level Authorization'
           url: 4-Web_Application_Security_Testing/12-API_Testing/04-API_Broken_Function_Level_Authorization
+          hints: 'bfla wstg-apit-04 apit-04'
         - title: '4.12.99 Testing GraphQL'
           url: 4-Web_Application_Security_Testing/12-API_Testing/99-Testing_GraphQL
+          hints: 'gql wstg-apit-99 apit-99'
 - title: '5. Reporting'
   url: 5-Reporting/README
   children:

--- a/_data/stable.yaml
+++ b/_data/stable.yaml
@@ -59,130 +59,184 @@ docs:
       children:
         - title: '4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage
+          hints: 'wstg-info-01 info-01'
         - title: '4.1.2 Fingerprint Web Server'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server
+          hints: 'wstg-info-02 info-02'
         - title: '4.1.3 Review Webserver Metafiles for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage
+          hints: 'robots robots.txt sitemap sitemap.xml wstg-info-03 info-03'
         - title: '4.1.4 Enumerate Applications on Webserver'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver
+          hints: 'wstg-info-04 info-04'
         - title: '4.1.5 Review Webpage Content for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage
+          hints: 'wstg-info-05 info-05'
         - title: '4.1.6 Identify Application Entry Points'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points
+          hints: 'wstg-info-06 info-06'
         - title: '4.1.7 Map Execution Paths Through Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application
+          hints: 'wstg-info-07 info-07'
         - title: '4.1.8 Fingerprint Web Application Framework'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework
+          hints: 'wstg-info-08 info-08'
         - title: '4.1.9 Fingerprint Web Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application
+          hints: 'wstg-info-09 info-09'
         - title: '4.1.10 Map Application Architecture'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture
+          hints: 'wstg-info-10 info-10'
     - title: '4.2 Configuration and Deployment Management Testing'
       url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/README
       children:
         - title: '4.2.1 Test Network Infrastructure Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration
+          hints: 'wstg-conf-01 conf-01'
         - title: '4.2.2 Test Application Platform Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration
+          hints: 'wstg-conf-02 conf-02'
         - title: '4.2.3 Test File Extensions Handling for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information
+          hints: 'wstg-conf-03 conf-03'
         - title: '4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
+          hints: 'wstg-conf-04 conf-04'
         - title: '4.2.5 Enumerate Infrastructure and Application Admin Interfaces'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces
+          hints: 'wstg-conf-05 conf-05'
         - title: '4.2.6 Test HTTP Methods'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods
+          hints: 'wstg-conf-06 conf-06'
         - title: '4.2.7 Test HTTP Strict Transport Security'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security
+          hints: 'hsts headers wstg-conf-07 conf-07'
         - title: '4.2.8 Test RIA Cross Domain Policy'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy
+          hints: 'crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08'
         - title: '4.2.9 Test File Permission'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission
+          hints: 'wstg-conf-09 conf-09'
         - title: '4.2.10 Test for Subdomain Takeover'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover
+          hints: 'wstg-conf-10 conf-10'
         - title: '4.2.11 Test Cloud Storage'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage
+          hints: 's3 bucket blob storage wstg-conf-11 conf-11'
     - title: '4.3 Identity Management Testing'
       url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/README
       children:
         - title: '4.3.1 Test Role Definitions'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions
+          hints: 'wstg-idnt-01 idnt-01'
         - title: '4.3.2 Test User Registration Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process
+          hints: 'wstg-idnt-02 idnt-02'
         - title: '4.3.3 Test Account Provisioning Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process
+          hints: 'wstg-idnt-03 idnt-03'
         - title: '4.3.4 Testing for Account Enumeration and Guessable User Account'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account
+          hints: 'wstg-idnt-04 idnt-04'
         - title: '4.3.5 Testing for Weak or Unenforced Username Policy'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy
+          hints: 'wstg-idnt-05 idnt-05'
     - title: '4.4 Authentication Testing'
       url: 4-Web_Application_Security_Testing/04-Authentication_Testing/README
       children:
         - title: '4.4.1 Testing for Credentials Transported over an Encrypted Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel
+          hints: 'tls ssl https wstg-athn-01 athn-01'
         - title: '4.4.2 Testing for Default Credentials'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials
+          hints: 'wstg-athn-02 athn-02'
         - title: '4.4.3 Testing for Weak Lock Out Mechanism'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism
+          hints: 'rate limit bruteforce brute force account lockout wstg-athn-03 athn-03'
         - title: '4.4.4 Testing for Bypassing Authentication Schema'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema
+          hints: 'wstg-athn-04 athn-04'
         - title: '4.4.5 Testing for Vulnerable Remember Password'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password
+          hints: 'wstg-athn-05 athn-05'
         - title: '4.4.6 Testing for Browser Cache Weaknesses'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses
+          hints: 'wstg-athn-06 athn-06'
         - title: '4.4.7 Testing for Weak Password Policy'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy
+          hints: 'wstg-athn-07 athn-07'
         - title: '4.4.8 Testing for Weak Security Question Answer'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer
+          hints: 'wstg-athn-08 athn-08'
         - title: '4.4.9 Testing for Weak Password Change or Reset Functionalities'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities
+          hints: 'wstg-athn-09 athn-09'
         - title: '4.4.10 Testing for Weaker Authentication in Alternative Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel
+          hints: 'wstg-athn-10 athn-10'
     - title: '4.5 Authorization Testing'
       url: 4-Web_Application_Security_Testing/05-Authorization_Testing/README
       children:
         - title: '4.5.1 Testing Directory Traversal File Include'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include
+          hints: 'path traversal dotdot lfi wstg-athz-01 athz-01'
         - title: '4.5.2 Testing for Bypassing Authorization Schema'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema
+          hints: 'wstg-athz-02 athz-02'
         - title: '4.5.3 Testing for Privilege Escalation'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation
+          hints: 'privesc wstg-athz-03 athz-03'
         - title: '4.5.4 Testing for Insecure Direct Object References'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References
+          hints: 'idor wstg-athz-04 athz-04'
     - title: '4.6 Session Management Testing'
       url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/README
       children:
         - title: '4.6.1 Testing for Session Management Schema'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema
+          hints: 'wstg-sess-01 sess-01'
         - title: '4.6.2 Testing for Cookies Attributes'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes
+          hints: 'cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02'
         - title: '4.6.3 Testing for Session Fixation'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation
+          hints: 'wstg-sess-03 sess-03'
         - title: '4.6.4 Testing for Exposed Session Variables'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables
+          hints: 'wstg-sess-04 sess-04'
         - title: '4.6.5 Testing for Cross Site Request Forgery'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery
+          hints: 'csrf xsrf wstg-sess-05 sess-05'
         - title: '4.6.6 Testing for Logout Functionality'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality
+          hints: 'wstg-sess-06 sess-06'
         - title: '4.6.7 Testing Session Timeout'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout
+          hints: 'wstg-sess-07 sess-07'
         - title: '4.6.8 Testing for Session Puzzling'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling
+          hints: 'wstg-sess-08 sess-08'
         - title: '4.6.9 Testing for Session Hijacking'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking
+          hints: 'wstg-sess-09 sess-09'
     - title: '4.7 Input Validation Testing'
       url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/README
       children:
         - title: '4.7.1 Testing for Reflected Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-01 inpv-01'
         - title: '4.7.2 Testing for Stored Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-02 inpv-02'
         - title: '4.7.3 Testing for HTTP Verb Tampering'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering
+          hints: 'verb tampering wstg-inpv-03 inpv-03'
         - title: '4.7.4 Testing for HTTP Parameter Pollution'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
+          hints: 'hpp wstg-inpv-04 inpv-04'
         - title: '4.7.5 Testing for SQL Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection
+          hints: 'sqli wstg-inpv-05 inpv-05'
           children:
             - title: '4.7.5.1 Testing for Oracle'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.1-Testing_for_Oracle
@@ -190,67 +244,91 @@ docs:
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL
             - title: '4.7.5.3 Testing for SQL Server'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server
+              hints: 'mssql sql server'
             - title: '4.7.5.4 Testing PostgreSQL'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.4-Testing_PostgreSQL
             - title: '4.7.5.5 Testing for MS Access'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access
             - title: '4.7.5.6 Testing for NoSQL Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection
+              hints: 'sqli nosqli'
             - title: '4.7.5.7 Testing for ORM Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection
             - title: '4.7.5.8 Testing for Client-side'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.8-Testing_for_Client-side
         - title: '4.7.6 Testing for LDAP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection
+          hints: 'ldapi wstg-inpv-06 inpv-06'
         - title: '4.7.7 Testing for XML Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection
+          hints: 'xxe xmli xml injection wstg-inpv-07 inpv-07'
         - title: '4.7.8 Testing for SSI Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection
+          hints: 'ssi injection wstg-inpv-08 inpv-08'
         - title: '4.7.9 Testing for XPath Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection
+          hints: 'xpathi xml wstg-inpv-09 inpv-09'
         - title: '4.7.10 Testing for IMAP SMTP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection
+          hints: 'email injection wstg-inpv-10 inpv-10'
         - title: '4.7.11 Testing for Code Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11-Testing_for_Code_Injection
+          hints: 'rce wstg-inpv-11 inpv-11'
           children:
             - title: '4.7.11.1 Testing for Local File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion
+              hints: 'lfi rfi'
             - title: '4.7.11.2 Testing for Remote File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion
+              hints: 'lfi rfi'
         - title: '4.7.12 Testing for Command Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection
+          hints: 'rce cmdi os command wstg-inpv-12 inpv-12'
         - title: '4.7.13 Testing for Format String Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection
+          hints: 'format string bug wstg-inpv-13 inpv-13'
         - title: '4.7.14 Testing for Incubated Vulnerability'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability
+          hints: 'wstg-inpv-14 inpv-14'
         - title: '4.7.15 Testing for HTTP Splitting Smuggling'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling
+          hints: 'wstg-inpv-15 inpv-15'
         - title: '4.7.16 Testing for HTTP Incoming Requests'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests
+          hints: 'wstg-inpv-16 inpv-16'
         - title: '4.7.17 Testing for Host Header Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
+          hints: 'host header injection headers wstg-inpv-17 inpv-17'
         - title: '4.7.18 Testing for Server-side Template Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection
+          hints: 'ssti wstg-inpv-18 inpv-18'
         - title: '4.7.19 Testing for Server-Side Request Forgery'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery
+          hints: 'ssrf wstg-inpv-19 inpv-19'
     - title: '4.8 Testing for Error Handling'
       url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/README
       children:
         - title: '4.8.1 Testing for Improper Error Handling'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling
+          hints: 'wstg-errh-01 errh-01'
         - title: '4.8.2 Testing for Stack Traces'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces
+          hints: 'wstg-errh-02 errh-02'
     - title: '4.9 Testing for Weak Cryptography'
       url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/README
       children:
         - title: '4.9.1 Testing for Weak Transport Layer Security'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security
+          hints: 'tls ssl https wstg-cryp-01 cryp-01'
         - title: '4.9.2 Testing for Padding Oracle'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle
+          hints: 'padding oracle attack wstg-cryp-02 cryp-02'
         - title: '4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels
+          hints: 'tls ssl https cleartext wstg-cryp-03 cryp-03'
         - title: '4.9.4 Testing for Weak Encryption'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption
+          hints: 'wstg-cryp-04 cryp-04'
     - title: '4.10 Business Logic Testing'
       url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/README
       children:
@@ -258,56 +336,79 @@ docs:
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic
         - title: '4.10.1 Test Business Logic Data Validation'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation
+          hints: 'wstg-busl-01 busl-01'
         - title: '4.10.2 Test Ability to Forge Requests'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests
+          hints: 'wstg-busl-02 busl-02'
         - title: '4.10.3 Test Integrity Checks'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks
+          hints: 'wstg-busl-03 busl-03'
         - title: '4.10.4 Test for Process Timing'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing
+          hints: 'race condition toctou wstg-busl-04 busl-04'
         - title: '4.10.5 Test Number of Times a Function Can Be Used Limits'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits
+          hints: 'rate limit bruteforce brute force wstg-busl-05 busl-05'
         - title: '4.10.6 Testing for the Circumvention of Work Flows'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows
+          hints: 'wstg-busl-06 busl-06'
         - title: '4.10.7 Test Defenses Against Application Misuse'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse
+          hints: 'wstg-busl-07 busl-07'
         - title: '4.10.8 Test Upload of Unexpected File Types'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types
+          hints: 'wstg-busl-08 busl-08'
         - title: '4.10.9 Test Upload of Malicious Files'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files
+          hints: 'wstg-busl-09 busl-09'
     - title: '4.11 Client-side Testing'
       url: 4-Web_Application_Security_Testing/11-Client-side_Testing/README
       children:
         - title: '4.11.1 Testing for DOM-Based Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting
+          hints: 'xss dom xss domxss wstg-clnt-01 clnt-01'
         - title: '4.11.2 Testing for JavaScript Execution'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution
+          hints: 'wstg-clnt-02 clnt-02'
         - title: '4.11.3 Testing for HTML Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection
+          hints: 'wstg-clnt-03 clnt-03'
         - title: '4.11.4 Testing for Client-side URL Redirect'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect
+          hints: 'open redirect wstg-clnt-04 clnt-04'
         - title: '4.11.5 Testing for CSS Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection
+          hints: 'wstg-clnt-05 clnt-05'
         - title: '4.11.6 Testing for Client-side Resource Manipulation'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation
+          hints: 'wstg-clnt-06 clnt-06'
         - title: '4.11.7 Testing Cross Origin Resource Sharing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing
+          hints: 'cors headers wstg-clnt-07 clnt-07'
         - title: '4.11.8 Testing for Cross Site Flashing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing
+          hints: 'wstg-clnt-08 clnt-08'
         - title: '4.11.9 Testing for Clickjacking'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking
+          hints: 'ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09'
         - title: '4.11.10 Testing WebSockets'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets
+          hints: 'ws wstg-clnt-10 clnt-10'
         - title: '4.11.11 Testing Web Messaging'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging
+          hints: 'postmessage post message wstg-clnt-11 clnt-11'
         - title: '4.11.12 Testing Browser Storage'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage
+          hints: 'localstorage sessionstorage wstg-clnt-12 clnt-12'
         - title: '4.11.13 Testing for Cross Site Script Inclusion'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion
+          hints: 'xssi wstg-clnt-13 clnt-13'
     - title: '4.12 API Testing'
       url: 4-Web_Application_Security_Testing/12-API_Testing/README
       children:
         - title: '4.12.1 Testing GraphQL'
           url: 4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL
+          hints: 'gql wstg-apit-01 apit-01'
 - title: '5. Reporting'
   url: 5-Reporting/README
 - title: 'Appendix A. Testing Tools Resource'

--- a/_data/v41.yaml
+++ b/_data/v41.yaml
@@ -59,128 +59,181 @@ docs:
       children:
         - title: '4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage
+          hints: 'wstg-info-01 info-01'
         - title: '4.1.2 Fingerprint Web Server'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server
+          hints: 'wstg-info-02 info-02'
         - title: '4.1.3 Review Webserver Metafiles for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage
+          hints: 'robots robots.txt sitemap sitemap.xml wstg-info-03 info-03'
         - title: '4.1.4 Enumerate Applications on Webserver'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver
+          hints: 'wstg-info-04 info-04'
         - title: '4.1.5 Review Webpage Comments and Metadata for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage
+          hints: 'wstg-info-05 info-05'
         - title: '4.1.6 Identify Application Entry Points'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points
+          hints: 'wstg-info-06 info-06'
         - title: '4.1.7 Map Execution Paths Through Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application
+          hints: 'wstg-info-07 info-07'
         - title: '4.1.8 Fingerprint Web Application Framework'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework
+          hints: 'wstg-info-08 info-08'
         - title: '4.1.9 Fingerprint Web Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application
+          hints: 'wstg-info-09 info-09'
         - title: '4.1.10 Map Application Architecture'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture
+          hints: 'wstg-info-10 info-10'
     - title: '4.2 Configuration and Deployment Management Testing'
       url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/README
       children:
         - title: '4.2.1 Test Network Infrastructure Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration
+          hints: 'wstg-conf-01 conf-01'
         - title: '4.2.2 Test Application Platform Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration
+          hints: 'wstg-conf-02 conf-02'
         - title: '4.2.3 Test File Extensions Handling for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information
+          hints: 'wstg-conf-03 conf-03'
         - title: '4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
+          hints: 'wstg-conf-04 conf-04'
         - title: '4.2.5 Enumerate Infrastructure and Application Admin Interfaces'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces
+          hints: 'wstg-conf-05 conf-05'
         - title: '4.2.6 Test HTTP Methods'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods
+          hints: 'wstg-conf-06 conf-06'
         - title: '4.2.7 Test HTTP Strict Transport Security'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security
+          hints: 'hsts headers wstg-conf-07 conf-07'
         - title: '4.2.8 Test RIA Cross Domain Policy'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy
+          hints: 'crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08'
         - title: '4.2.9 Test File Permission'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission
+          hints: 'wstg-conf-09 conf-09'
         - title: '4.2.10 Test for Subdomain Takeover'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover
+          hints: 'wstg-conf-10 conf-10'
         - title: '4.2.11 Test Cloud Storage'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage
+          hints: 's3 bucket blob storage wstg-conf-11 conf-11'
     - title: '4.3 Identity Management Testing'
       url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/README
       children:
         - title: '4.3.1 Test Role Definitions'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions
+          hints: 'wstg-idnt-01 idnt-01'
         - title: '4.3.2 Test User Registration Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process
+          hints: 'wstg-idnt-02 idnt-02'
         - title: '4.3.3 Test Account Provisioning Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process
+          hints: 'wstg-idnt-03 idnt-03'
         - title: '4.3.4 Testing for Account Enumeration and Guessable User Account'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account
+          hints: 'wstg-idnt-04 idnt-04'
         - title: '4.3.5 Testing for Weak or Unenforced Username Policy'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy
+          hints: 'wstg-idnt-05 idnt-05'
     - title: '4.4 Authentication Testing'
       url: 4-Web_Application_Security_Testing/04-Authentication_Testing/README
       children:
         - title: '4.4.1 Testing for Credentials Transported over an Encrypted Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel
+          hints: 'tls ssl https wstg-athn-01 athn-01'
         - title: '4.4.2 Testing for Default Credentials'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials
+          hints: 'wstg-athn-02 athn-02'
         - title: '4.4.3 Testing for Weak Lock Out Mechanism'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism
+          hints: 'rate limit bruteforce brute force account lockout wstg-athn-03 athn-03'
         - title: '4.4.4 Testing for Bypassing Authentication Schema'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema
+          hints: 'wstg-athn-04 athn-04'
         - title: '4.4.5 Testing for Vulnerable Remember Password'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password
+          hints: 'wstg-athn-05 athn-05'
         - title: '4.4.6 Testing for Browser Cache Weaknesses'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses
+          hints: 'wstg-athn-06 athn-06'
         - title: '4.4.7 Testing for Weak Password Policy'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy
+          hints: 'wstg-athn-07 athn-07'
         - title: '4.4.8 Testing for Weak Security Question Answer'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer
+          hints: 'wstg-athn-08 athn-08'
         - title: '4.4.9 Testing for Weak Password Change or Reset Functionalities'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities
+          hints: 'wstg-athn-09 athn-09'
         - title: '4.4.10 Testing for Weaker Authentication in Alternative Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel
+          hints: 'wstg-athn-10 athn-10'
     - title: '4.5 Authorization Testing'
       url: 4-Web_Application_Security_Testing/05-Authorization_Testing/README
       children:
         - title: '4.5.1 Testing Directory Traversal File Include'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include
+          hints: 'path traversal dotdot lfi wstg-athz-01 athz-01'
         - title: '4.5.2 Testing for Bypassing Authorization Schema'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema
+          hints: 'wstg-athz-02 athz-02'
         - title: '4.5.3 Testing for Privilege Escalation'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation
+          hints: 'privesc wstg-athz-03 athz-03'
         - title: '4.5.4 Testing for Insecure Direct Object References'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References
+          hints: 'idor wstg-athz-04 athz-04'
     - title: '4.6 Session Management Testing'
       url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/README
       children:
         - title: '4.6.1 Testing for Session Management Schema'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema
+          hints: 'wstg-sess-01 sess-01'
         - title: '4.6.2 Testing for Cookies Attributes'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes
+          hints: 'cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02'
         - title: '4.6.3 Testing for Session Fixation'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation
+          hints: 'wstg-sess-03 sess-03'
         - title: '4.6.4 Testing for Exposed Session Variables'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables
+          hints: 'wstg-sess-04 sess-04'
         - title: '4.6.5 Testing for Cross Site Request Forgery'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery
+          hints: 'csrf xsrf wstg-sess-05 sess-05'
         - title: '4.6.6 Testing for Logout Functionality'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality
+          hints: 'wstg-sess-06 sess-06'
         - title: '4.6.7 Testing Session Timeout'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout
+          hints: 'wstg-sess-07 sess-07'
         - title: '4.6.8 Testing for Session Puzzling'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling
+          hints: 'wstg-sess-08 sess-08'
     - title: '4.7 Input Validation Testing'
       url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/README
       children:
         - title: '4.7.1 Testing for Reflected Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-01 inpv-01'
         - title: '4.7.2 Testing for Stored Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-02 inpv-02'
         - title: '4.7.3 Testing for HTTP Verb Tampering'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering
+          hints: 'verb tampering wstg-inpv-03 inpv-03'
         - title: '4.7.4 Testing for HTTP Parameter Pollution'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
+          hints: 'hpp wstg-inpv-04 inpv-04'
         - title: '4.7.5 Testing for SQL Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection
+          hints: 'sqli wstg-inpv-05 inpv-05'
           children:
             - title: '4.7.5.1 Testing for Oracle'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.1-Testing_for_Oracle
@@ -188,37 +241,49 @@ docs:
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL
             - title: '4.7.5.3 Testing for SQL Server'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server
+              hints: 'mssql sql server'
             - title: '4.7.5.4 Testing PostgreSQL'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.4-Testing_PostgreSQL
             - title: '4.7.5.5 Testing for MS Access'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access
             - title: '4.7.5.6 Testing for NoSQL Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection
+              hints: 'sqli nosqli'
             - title: '4.7.5.7 Testing for ORM Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection
             - title: '4.7.5.8 Testing for Client Side'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.8-Testing_for_Client_Side
         - title: '4.7.6 Testing for LDAP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection
+          hints: 'ldapi wstg-inpv-06 inpv-06'
         - title: '4.7.7 Testing for XML Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection
+          hints: 'xxe xmli xml injection wstg-inpv-07 inpv-07'
         - title: '4.7.8 Testing for SSI Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection
+          hints: 'ssi injection wstg-inpv-08 inpv-08'
         - title: '4.7.9 Testing for XPath Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection
+          hints: 'xpathi xml wstg-inpv-09 inpv-09'
         - title: '4.7.10 Testing for IMAP SMTP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection
+          hints: 'email injection wstg-inpv-10 inpv-10'
         - title: '4.7.11 Testing for Code Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11-Testing_for_Code_Injection
+          hints: 'rce wstg-inpv-11 inpv-11'
           children:
             - title: '4.7.11.1 Testing for Local File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion
+              hints: 'lfi rfi'
             - title: '4.7.11.2 Testing for Remote File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion
+              hints: 'lfi rfi'
         - title: '4.7.12 Testing for Command Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection
+          hints: 'rce cmdi os command wstg-inpv-12 inpv-12'
         - title: '4.7.13 Testing for Buffer Overflow'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Buffer_Overflow
+          hints: 'wstg-inpv-13 inpv-13'
           children:
             - title: '4.7.13.1 Testing for Heap Overflow'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.1-Testing_for_Heap_Overflow
@@ -226,34 +291,46 @@ docs:
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.2-Testing_for_Stack_Overflow
             - title: '4.7.13.3 Testing for Format String'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.3-Testing_for_Format_String
+              hints: 'format string bug'
         - title: '4.7.14 Testing for Incubated Vulnerability'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability
+          hints: 'wstg-inpv-14 inpv-14'
         - title: '4.7.15 Testing for HTTP Splitting Smuggling'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling
+          hints: 'wstg-inpv-15 inpv-15'
         - title: '4.7.16 Testing for HTTP Incoming Requests'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests
+          hints: 'wstg-inpv-16 inpv-16'
         - title: '4.7.17 Testing for Host Header Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
+          hints: 'host header injection headers wstg-inpv-17 inpv-17'
         - title: '4.7.18 Testing for Server Side Template Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection
+          hints: 'ssti wstg-inpv-18 inpv-18'
     - title: '4.8 Testing for Error Handling'
       url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/README
       children:
         - title: '4.8.1 Testing for Error Code'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_for_Error_Code
+          hints: 'wstg-errh-01 errh-01'
         - title: '4.8.2 Testing for Stack Traces'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces
+          hints: 'wstg-errh-02 errh-02'
     - title: '4.9 Testing for Weak Cryptography'
       url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/README
       children:
         - title: '4.9.1 Testing for Weak SSL TLS Ciphers Insufficient Transport Layer Protection'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection
+          hints: 'wstg-cryp-01 cryp-01'
         - title: '4.9.2 Testing for Padding Oracle'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle
+          hints: 'padding oracle attack wstg-cryp-02 cryp-02'
         - title: '4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels
+          hints: 'tls ssl https cleartext wstg-cryp-03 cryp-03'
         - title: '4.9.4 Testing for Weak Encryption'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption
+          hints: 'wstg-cryp-04 cryp-04'
     - title: '4.10 Business Logic Testing'
       url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/README
       children:
@@ -261,51 +338,73 @@ docs:
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic
         - title: '4.10.1 Test Business Logic Data Validation'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation
+          hints: 'wstg-busl-01 busl-01'
         - title: '4.10.2 Test Ability to Forge Requests'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests
+          hints: 'wstg-busl-02 busl-02'
         - title: '4.10.3 Test Integrity Checks'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks
+          hints: 'wstg-busl-03 busl-03'
         - title: '4.10.4 Test for Process Timing'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing
+          hints: 'race condition toctou wstg-busl-04 busl-04'
         - title: '4.10.5 Test Number of Times a Function Can Be Used Limits'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits
+          hints: 'rate limit bruteforce brute force wstg-busl-05 busl-05'
         - title: '4.10.6 Testing for the Circumvention of Work Flows'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows
+          hints: 'wstg-busl-06 busl-06'
         - title: '4.10.7 Test Defenses Against Application Misuse'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse
+          hints: 'wstg-busl-07 busl-07'
         - title: '4.10.8 Test Upload of Unexpected File Types'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types
+          hints: 'wstg-busl-08 busl-08'
         - title: '4.10.9 Test Upload of Malicious Files'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files
+          hints: 'wstg-busl-09 busl-09'
     - title: '4.11 Client Side Testing'
       url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/README
       children:
         - title: '4.11.1 Testing for DOM-Based Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting
+          hints: 'xss dom xss domxss wstg-clnt-01 clnt-01'
         - title: '4.11.2 Testing for JavaScript Execution'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/02-Testing_for_JavaScript_Execution
+          hints: 'wstg-clnt-02 clnt-02'
         - title: '4.11.3 Testing for HTML Injection'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/03-Testing_for_HTML_Injection
+          hints: 'wstg-clnt-03 clnt-03'
         - title: '4.11.4 Testing for Client Side URL Redirect'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/04-Testing_for_Client_Side_URL_Redirect
+          hints: 'open redirect wstg-clnt-04 clnt-04'
         - title: '4.11.5 Testing for CSS Injection'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection
+          hints: 'wstg-clnt-05 clnt-05'
         - title: '4.11.6 Testing for Client Side Resource Manipulation'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/06-Testing_for_Client_Side_Resource_Manipulation
+          hints: 'wstg-clnt-06 clnt-06'
         - title: '4.11.7 Testing Cross Origin Resource Sharing'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/07-Testing_Cross_Origin_Resource_Sharing
+          hints: 'cors headers wstg-clnt-07 clnt-07'
         - title: '4.11.8 Testing for Cross Site Flashing'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/08-Testing_for_Cross_Site_Flashing
+          hints: 'wstg-clnt-08 clnt-08'
         - title: '4.11.9 Testing for Clickjacking'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking
+          hints: 'ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09'
         - title: '4.11.10 Testing WebSockets'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets
+          hints: 'ws wstg-clnt-10 clnt-10'
         - title: '4.11.11 Testing Web Messaging'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/11-Testing_Web_Messaging
+          hints: 'postmessage post message wstg-clnt-11 clnt-11'
         - title: '4.11.12 Testing Browser Storage'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/12-Testing_Browser_Storage
+          hints: 'localstorage sessionstorage wstg-clnt-12 clnt-12'
         - title: '4.11.13 Testing for Cross Site Script Inclusion'
           url: 4-Web_Application_Security_Testing/11-Client_Side_Testing/13-Testing_for_Cross_Site_Script_Inclusion
+          hints: 'xssi wstg-clnt-13 clnt-13'
 - title: '5. Reporting'
   url: 5-Reporting/README
 - title: 'Appendix A. Testing Tools Resource'

--- a/_data/v42.yaml
+++ b/_data/v42.yaml
@@ -59,130 +59,184 @@ docs:
       children:
         - title: '4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage
+          hints: 'wstg-info-01 info-01'
         - title: '4.1.2 Fingerprint Web Server'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server
+          hints: 'wstg-info-02 info-02'
         - title: '4.1.3 Review Webserver Metafiles for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage
+          hints: 'robots robots.txt sitemap sitemap.xml wstg-info-03 info-03'
         - title: '4.1.4 Enumerate Applications on Webserver'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver
+          hints: 'wstg-info-04 info-04'
         - title: '4.1.5 Review Webpage Content for Information Leakage'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage
+          hints: 'wstg-info-05 info-05'
         - title: '4.1.6 Identify Application Entry Points'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points
+          hints: 'wstg-info-06 info-06'
         - title: '4.1.7 Map Execution Paths Through Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application
+          hints: 'wstg-info-07 info-07'
         - title: '4.1.8 Fingerprint Web Application Framework'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework
+          hints: 'wstg-info-08 info-08'
         - title: '4.1.9 Fingerprint Web Application'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application
+          hints: 'wstg-info-09 info-09'
         - title: '4.1.10 Map Application Architecture'
           url: 4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture
+          hints: 'wstg-info-10 info-10'
     - title: '4.2 Configuration and Deployment Management Testing'
       url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/README
       children:
         - title: '4.2.1 Test Network Infrastructure Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration
+          hints: 'wstg-conf-01 conf-01'
         - title: '4.2.2 Test Application Platform Configuration'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration
+          hints: 'wstg-conf-02 conf-02'
         - title: '4.2.3 Test File Extensions Handling for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information
+          hints: 'wstg-conf-03 conf-03'
         - title: '4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
+          hints: 'wstg-conf-04 conf-04'
         - title: '4.2.5 Enumerate Infrastructure and Application Admin Interfaces'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces
+          hints: 'wstg-conf-05 conf-05'
         - title: '4.2.6 Test HTTP Methods'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods
+          hints: 'wstg-conf-06 conf-06'
         - title: '4.2.7 Test HTTP Strict Transport Security'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security
+          hints: 'hsts headers wstg-conf-07 conf-07'
         - title: '4.2.8 Test RIA Cross Domain Policy'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy
+          hints: 'crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08'
         - title: '4.2.9 Test File Permission'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission
+          hints: 'wstg-conf-09 conf-09'
         - title: '4.2.10 Test for Subdomain Takeover'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover
+          hints: 'wstg-conf-10 conf-10'
         - title: '4.2.11 Test Cloud Storage'
           url: 4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage
+          hints: 's3 bucket blob storage wstg-conf-11 conf-11'
     - title: '4.3 Identity Management Testing'
       url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/README
       children:
         - title: '4.3.1 Test Role Definitions'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions
+          hints: 'wstg-idnt-01 idnt-01'
         - title: '4.3.2 Test User Registration Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process
+          hints: 'wstg-idnt-02 idnt-02'
         - title: '4.3.3 Test Account Provisioning Process'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process
+          hints: 'wstg-idnt-03 idnt-03'
         - title: '4.3.4 Testing for Account Enumeration and Guessable User Account'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account
+          hints: 'wstg-idnt-04 idnt-04'
         - title: '4.3.5 Testing for Weak or Unenforced Username Policy'
           url: 4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy
+          hints: 'wstg-idnt-05 idnt-05'
     - title: '4.4 Authentication Testing'
       url: 4-Web_Application_Security_Testing/04-Authentication_Testing/README
       children:
         - title: '4.4.1 Testing for Credentials Transported over an Encrypted Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel
+          hints: 'tls ssl https wstg-athn-01 athn-01'
         - title: '4.4.2 Testing for Default Credentials'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials
+          hints: 'wstg-athn-02 athn-02'
         - title: '4.4.3 Testing for Weak Lock Out Mechanism'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism
+          hints: 'rate limit bruteforce brute force account lockout wstg-athn-03 athn-03'
         - title: '4.4.4 Testing for Bypassing Authentication Schema'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema
+          hints: 'wstg-athn-04 athn-04'
         - title: '4.4.5 Testing for Vulnerable Remember Password'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password
+          hints: 'wstg-athn-05 athn-05'
         - title: '4.4.6 Testing for Browser Cache Weaknesses'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses
+          hints: 'wstg-athn-06 athn-06'
         - title: '4.4.7 Testing for Weak Password Policy'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy
+          hints: 'wstg-athn-07 athn-07'
         - title: '4.4.8 Testing for Weak Security Question Answer'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer
+          hints: 'wstg-athn-08 athn-08'
         - title: '4.4.9 Testing for Weak Password Change or Reset Functionalities'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities
+          hints: 'wstg-athn-09 athn-09'
         - title: '4.4.10 Testing for Weaker Authentication in Alternative Channel'
           url: 4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel
+          hints: 'wstg-athn-10 athn-10'
     - title: '4.5 Authorization Testing'
       url: 4-Web_Application_Security_Testing/05-Authorization_Testing/README
       children:
         - title: '4.5.1 Testing Directory Traversal File Include'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include
+          hints: 'path traversal dotdot lfi wstg-athz-01 athz-01'
         - title: '4.5.2 Testing for Bypassing Authorization Schema'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema
+          hints: 'wstg-athz-02 athz-02'
         - title: '4.5.3 Testing for Privilege Escalation'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation
+          hints: 'privesc wstg-athz-03 athz-03'
         - title: '4.5.4 Testing for Insecure Direct Object References'
           url: 4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References
+          hints: 'idor wstg-athz-04 athz-04'
     - title: '4.6 Session Management Testing'
       url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/README
       children:
         - title: '4.6.1 Testing for Session Management Schema'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema
+          hints: 'wstg-sess-01 sess-01'
         - title: '4.6.2 Testing for Cookies Attributes'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes
+          hints: 'cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02'
         - title: '4.6.3 Testing for Session Fixation'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation
+          hints: 'wstg-sess-03 sess-03'
         - title: '4.6.4 Testing for Exposed Session Variables'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables
+          hints: 'wstg-sess-04 sess-04'
         - title: '4.6.5 Testing for Cross Site Request Forgery'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery
+          hints: 'csrf xsrf wstg-sess-05 sess-05'
         - title: '4.6.6 Testing for Logout Functionality'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality
+          hints: 'wstg-sess-06 sess-06'
         - title: '4.6.7 Testing Session Timeout'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout
+          hints: 'wstg-sess-07 sess-07'
         - title: '4.6.8 Testing for Session Puzzling'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling
+          hints: 'wstg-sess-08 sess-08'
         - title: '4.6.9 Testing for Session Hijacking'
           url: 4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking
+          hints: 'wstg-sess-09 sess-09'
     - title: '4.7 Input Validation Testing'
       url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/README
       children:
         - title: '4.7.1 Testing for Reflected Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-01 inpv-01'
         - title: '4.7.2 Testing for Stored Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting
+          hints: 'xss wstg-inpv-02 inpv-02'
         - title: '4.7.3 Testing for HTTP Verb Tampering'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering
+          hints: 'verb tampering wstg-inpv-03 inpv-03'
         - title: '4.7.4 Testing for HTTP Parameter Pollution'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
+          hints: 'hpp wstg-inpv-04 inpv-04'
         - title: '4.7.5 Testing for SQL Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection
+          hints: 'sqli wstg-inpv-05 inpv-05'
           children:
             - title: '4.7.5.1 Testing for Oracle'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.1-Testing_for_Oracle
@@ -190,67 +244,91 @@ docs:
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL
             - title: '4.7.5.3 Testing for SQL Server'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server
+              hints: 'mssql sql server'
             - title: '4.7.5.4 Testing PostgreSQL'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.4-Testing_PostgreSQL
             - title: '4.7.5.5 Testing for MS Access'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access
             - title: '4.7.5.6 Testing for NoSQL Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection
+              hints: 'sqli nosqli'
             - title: '4.7.5.7 Testing for ORM Injection'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.7-Testing_for_ORM_Injection
             - title: '4.7.5.8 Testing for Client-side'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.8-Testing_for_Client-side
         - title: '4.7.6 Testing for LDAP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection
+          hints: 'ldapi wstg-inpv-06 inpv-06'
         - title: '4.7.7 Testing for XML Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection
+          hints: 'xxe xmli xml injection wstg-inpv-07 inpv-07'
         - title: '4.7.8 Testing for SSI Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection
+          hints: 'ssi injection wstg-inpv-08 inpv-08'
         - title: '4.7.9 Testing for XPath Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection
+          hints: 'xpathi xml wstg-inpv-09 inpv-09'
         - title: '4.7.10 Testing for IMAP SMTP Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection
+          hints: 'email injection wstg-inpv-10 inpv-10'
         - title: '4.7.11 Testing for Code Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11-Testing_for_Code_Injection
+          hints: 'rce wstg-inpv-11 inpv-11'
           children:
             - title: '4.7.11.1 Testing for Local File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion
+              hints: 'lfi rfi'
             - title: '4.7.11.2 Testing for Remote File Inclusion'
               url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion
+              hints: 'lfi rfi'
         - title: '4.7.12 Testing for Command Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection
+          hints: 'rce cmdi os command wstg-inpv-12 inpv-12'
         - title: '4.7.13 Testing for Format String Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection
+          hints: 'format string bug wstg-inpv-13 inpv-13'
         - title: '4.7.14 Testing for Incubated Vulnerability'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability
+          hints: 'wstg-inpv-14 inpv-14'
         - title: '4.7.15 Testing for HTTP Splitting Smuggling'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling
+          hints: 'wstg-inpv-15 inpv-15'
         - title: '4.7.16 Testing for HTTP Incoming Requests'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests
+          hints: 'wstg-inpv-16 inpv-16'
         - title: '4.7.17 Testing for Host Header Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
+          hints: 'host header injection headers wstg-inpv-17 inpv-17'
         - title: '4.7.18 Testing for Server-side Template Injection'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection
+          hints: 'ssti wstg-inpv-18 inpv-18'
         - title: '4.7.19 Testing for Server-Side Request Forgery'
           url: 4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery
+          hints: 'ssrf wstg-inpv-19 inpv-19'
     - title: '4.8 Testing for Error Handling'
       url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/README
       children:
         - title: '4.8.1 Testing for Improper Error Handling'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling
+          hints: 'wstg-errh-01 errh-01'
         - title: '4.8.2 Testing for Stack Traces'
           url: 4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces
+          hints: 'wstg-errh-02 errh-02'
     - title: '4.9 Testing for Weak Cryptography'
       url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/README
       children:
         - title: '4.9.1 Testing for Weak Transport Layer Security'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security
+          hints: 'tls ssl https wstg-cryp-01 cryp-01'
         - title: '4.9.2 Testing for Padding Oracle'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle
+          hints: 'padding oracle attack wstg-cryp-02 cryp-02'
         - title: '4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels
+          hints: 'tls ssl https cleartext wstg-cryp-03 cryp-03'
         - title: '4.9.4 Testing for Weak Encryption'
           url: 4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption
+          hints: 'wstg-cryp-04 cryp-04'
     - title: '4.10 Business Logic Testing'
       url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/README
       children:
@@ -258,56 +336,79 @@ docs:
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic
         - title: '4.10.1 Test Business Logic Data Validation'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation
+          hints: 'wstg-busl-01 busl-01'
         - title: '4.10.2 Test Ability to Forge Requests'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests
+          hints: 'wstg-busl-02 busl-02'
         - title: '4.10.3 Test Integrity Checks'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks
+          hints: 'wstg-busl-03 busl-03'
         - title: '4.10.4 Test for Process Timing'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing
+          hints: 'race condition toctou wstg-busl-04 busl-04'
         - title: '4.10.5 Test Number of Times a Function Can Be Used Limits'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits
+          hints: 'rate limit bruteforce brute force wstg-busl-05 busl-05'
         - title: '4.10.6 Testing for the Circumvention of Work Flows'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows
+          hints: 'wstg-busl-06 busl-06'
         - title: '4.10.7 Test Defenses Against Application Misuse'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse
+          hints: 'wstg-busl-07 busl-07'
         - title: '4.10.8 Test Upload of Unexpected File Types'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types
+          hints: 'wstg-busl-08 busl-08'
         - title: '4.10.9 Test Upload of Malicious Files'
           url: 4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files
+          hints: 'wstg-busl-09 busl-09'
     - title: '4.11 Client-side Testing'
       url: 4-Web_Application_Security_Testing/11-Client-side_Testing/README
       children:
         - title: '4.11.1 Testing for DOM-Based Cross Site Scripting'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting
+          hints: 'xss dom xss domxss wstg-clnt-01 clnt-01'
         - title: '4.11.2 Testing for JavaScript Execution'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution
+          hints: 'wstg-clnt-02 clnt-02'
         - title: '4.11.3 Testing for HTML Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection
+          hints: 'wstg-clnt-03 clnt-03'
         - title: '4.11.4 Testing for Client-side URL Redirect'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect
+          hints: 'open redirect wstg-clnt-04 clnt-04'
         - title: '4.11.5 Testing for CSS Injection'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection
+          hints: 'wstg-clnt-05 clnt-05'
         - title: '4.11.6 Testing for Client-side Resource Manipulation'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation
+          hints: 'wstg-clnt-06 clnt-06'
         - title: '4.11.7 Testing Cross Origin Resource Sharing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing
+          hints: 'cors headers wstg-clnt-07 clnt-07'
         - title: '4.11.8 Testing for Cross Site Flashing'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing
+          hints: 'wstg-clnt-08 clnt-08'
         - title: '4.11.9 Testing for Clickjacking'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking
+          hints: 'ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09'
         - title: '4.11.10 Testing WebSockets'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets
+          hints: 'ws wstg-clnt-10 clnt-10'
         - title: '4.11.11 Testing Web Messaging'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging
+          hints: 'postmessage post message wstg-clnt-11 clnt-11'
         - title: '4.11.12 Testing Browser Storage'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage
+          hints: 'localstorage sessionstorage wstg-clnt-12 clnt-12'
         - title: '4.11.13 Testing for Cross Site Script Inclusion'
           url: 4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion
+          hints: 'xssi wstg-clnt-13 clnt-13'
     - title: '4.12 API Testing'
       url: 4-Web_Application_Security_Testing/12-API_Testing/README
       children:
         - title: '4.12.1 Testing GraphQL'
           url: 4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL
+          hints: 'gql wstg-apit-01 apit-01'
 - title: '5. Reporting'
   url: 5-Reporting/README
 - title: 'Appendix A. Testing Tools Resource'

--- a/_includes/nav-tree-latest.html
+++ b/_includes/nav-tree-latest.html
@@ -107,34 +107,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage" data-hints="wstg-info-01 info-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server">
+<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server" data-hints="wstg-info-02 info-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" title="4.1.2 Fingerprint Web Server">4.1.2 Fingerprint Web Server</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage" data-hints="robots robots.txt sitemap sitemap.xml wstg-info-03 info-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" title="4.1.3 Review Webserver Metafiles for Information Leakage">4.1.3 Review Webserver Metafiles for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.4 Attack Surface Identification">
+<li class="wstg-nav-item" data-title="4.1.4 Attack Surface Identification" data-hints="wstg-info-04 info-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/04-Attack_Surface_Identification" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/04-Attack_Surface_Identification" title="4.1.4 Attack Surface Identification">4.1.4 Attack Surface Identification</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.5 Review Web Page Content for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.5 Review Web Page Content for Information Leakage" data-hints="wstg-info-05 info-05">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Web_Page_Content_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Web_Page_Content_for_Information_Leakage" title="4.1.5 Review Web Page Content for Information Leakage">4.1.5 Review Web Page Content for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points">
+<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points" data-hints="wstg-info-06 info-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" title="4.1.6 Identify Application Entry Points">4.1.6 Identify Application Entry Points</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application">
+<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application" data-hints="wstg-info-07 info-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" title="4.1.7 Map Execution Paths Through Application">4.1.7 Map Execution Paths Through Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework">
+<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework" data-hints="wstg-info-08 info-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" title="4.1.8 Fingerprint Web Application Framework">4.1.8 Fingerprint Web Application Framework</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application">
+<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application" data-hints="wstg-info-09 info-09 wstg-info-08 info-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" title="4.1.9 Fingerprint Web Application">4.1.9 Fingerprint Web Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture">
+<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture" data-hints="wstg-info-10 info-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" title="4.1.10 Map Application Architecture">4.1.10 Map Application Architecture</a>
 </li>
 </ul>
@@ -149,46 +149,46 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration">
+<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration" data-hints="wstg-conf-01 conf-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" title="4.2.1 Test Network Infrastructure Configuration">4.2.1 Test Network Infrastructure Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration">
+<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration" data-hints="wstg-conf-02 conf-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" title="4.2.2 Test Application Platform Configuration">4.2.2 Test Application Platform Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information" data-hints="wstg-conf-03 conf-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" title="4.2.3 Test File Extensions Handling for Sensitive Information">4.2.3 Test File Extensions Handling for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information" data-hints="wstg-conf-04 conf-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">
+<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces" data-hints="wstg-conf-05 conf-05">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">4.2.5 Enumerate Infrastructure and Application Admin Interfaces</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods">
+<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods" data-hints="wstg-conf-06 conf-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" title="4.2.6 Test HTTP Methods">4.2.6 Test HTTP Methods</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security">
+<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security" data-hints="hsts headers wstg-conf-07 conf-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" title="4.2.7 Test HTTP Strict Transport Security">4.2.7 Test HTTP Strict Transport Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy">
+<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy" data-hints="crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" title="4.2.8 Test RIA Cross Domain Policy">4.2.8 Test RIA Cross Domain Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.9 Test File Permission">
+<li class="wstg-nav-item" data-title="4.2.9 Test File Permission" data-hints="wstg-conf-09 conf-09">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" title="4.2.9 Test File Permission">4.2.9 Test File Permission</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover">
+<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover" data-hints="wstg-conf-10 conf-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" title="4.2.10 Test for Subdomain Takeover">4.2.10 Test for Subdomain Takeover</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage">
+<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage" data-hints="s3 bucket blob storage wstg-conf-11 conf-11">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" title="4.2.11 Test Cloud Storage">4.2.11 Test Cloud Storage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.12 Test for Content Security Policy">
+<li class="wstg-nav-item" data-title="4.2.12 Test for Content Security Policy" data-hints="csp headers wstg-conf-12 conf-12">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy" title="4.2.12 Test for Content Security Policy">4.2.12 Test for Content Security Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.13 Test for Path Confusion">
+<li class="wstg-nav-item" data-title="4.2.13 Test for Path Confusion" data-hints="wstg-conf-13 conf-13">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/13-Test_for_Path_Confusion" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/13-Test_for_Path_Confusion" title="4.2.13 Test for Path Confusion">4.2.13 Test for Path Confusion</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.14 Test Other HTTP Security Header Misconfigurations">
+<li class="wstg-nav-item" data-title="4.2.14 Test Other HTTP Security Header Misconfigurations" data-hints="headers wstg-conf-14 conf-14">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/14-Test_Other_HTTP_Security_Header_Misconfigurations" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/14-Test_Other_HTTP_Security_Header_Misconfigurations" title="4.2.14 Test Other HTTP Security Header Misconfigurations">4.2.14 Test Other HTTP Security Header Misconfigurations</a>
 </li>
 </ul>
@@ -203,19 +203,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions">
+<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions" data-hints="wstg-idnt-01 idnt-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" title="4.3.1 Test Role Definitions">4.3.1 Test Role Definitions</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process">
+<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process" data-hints="wstg-idnt-02 idnt-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" title="4.3.2 Test User Registration Process">4.3.2 Test User Registration Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process">
+<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process" data-hints="wstg-idnt-03 idnt-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" title="4.3.3 Test Account Provisioning Process">4.3.3 Test Account Provisioning Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account">
+<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account" data-hints="wstg-idnt-04 idnt-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" title="4.3.4 Testing for Account Enumeration and Guessable User Account">4.3.4 Testing for Account Enumeration and Guessable User Account</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy">
+<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy" data-hints="wstg-idnt-05 idnt-05 wstg-idnt-04 idnt-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" title="4.3.5 Testing for Weak or Unenforced Username Policy">4.3.5 Testing for Weak or Unenforced Username Policy</a>
 </li>
 </ul>
@@ -230,37 +230,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">
+<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel" data-hints="tls ssl https wstg-athn-01 athn-01 wstg-cryp-03 cryp-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">4.4.1 Testing for Credentials Transported over an Encrypted Channel</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials">
+<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials" data-hints="wstg-athn-02 athn-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" title="4.4.2 Testing for Default Credentials">4.4.2 Testing for Default Credentials</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism">
+<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism" data-hints="rate limit bruteforce brute force account lockout wstg-athn-03 athn-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" title="4.4.3 Testing for Weak Lock Out Mechanism">4.4.3 Testing for Weak Lock Out Mechanism</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema">
+<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema" data-hints="wstg-athn-04 athn-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" title="4.4.4 Testing for Bypassing Authentication Schema">4.4.4 Testing for Bypassing Authentication Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password">
+<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password" data-hints="wstg-athn-05 athn-05">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" title="4.4.5 Testing for Vulnerable Remember Password">4.4.5 Testing for Vulnerable Remember Password</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses">
+<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses" data-hints="wstg-athn-06 athn-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" title="4.4.6 Testing for Browser Cache Weaknesses">4.4.6 Testing for Browser Cache Weaknesses</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Authentication Methods">
+<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Authentication Methods" data-hints="wstg-athn-07 athn-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Authentication_Methods" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Authentication_Methods" title="4.4.7 Testing for Weak Authentication Methods">4.4.7 Testing for Weak Authentication Methods</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer">
+<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer" data-hints="wstg-athn-08 athn-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" title="4.4.8 Testing for Weak Security Question Answer">4.4.8 Testing for Weak Security Question Answer</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities">
+<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities" data-hints="wstg-athn-09 athn-09">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" title="4.4.9 Testing for Weak Password Change or Reset Functionalities">4.4.9 Testing for Weak Password Change or Reset Functionalities</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel">
+<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel" data-hints="wstg-athn-10 athn-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" title="4.4.10 Testing for Weaker Authentication in Alternative Channel">4.4.10 Testing for Weaker Authentication in Alternative Channel</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.11 Testing Multi-Factor Authentication">
+<li class="wstg-nav-item" data-title="4.4.11 Testing Multi-Factor Authentication" data-hints="mfa 2fa totp wstg-athn-11 athn-11">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/11-Testing_Multi-Factor_Authentication" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/11-Testing_Multi-Factor_Authentication" title="4.4.11 Testing Multi-Factor Authentication">4.4.11 Testing Multi-Factor Authentication</a>
 </li>
 </ul>
@@ -275,19 +275,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include">
+<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include" data-hints="path traversal dotdot lfi wstg-athz-01 athz-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" title="4.5.1 Testing Directory Traversal File Include">4.5.1 Testing Directory Traversal File Include</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema">
+<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema" data-hints="wstg-athz-02 athz-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" title="4.5.2 Testing for Bypassing Authorization Schema">4.5.2 Testing for Bypassing Authorization Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation">
+<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation" data-hints="privesc wstg-athz-03 athz-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" title="4.5.3 Testing for Privilege Escalation">4.5.3 Testing for Privilege Escalation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References">
+<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References" data-hints="idor wstg-athz-04 athz-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" title="4.5.4 Testing for Insecure Direct Object References">4.5.4 Testing for Insecure Direct Object References</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.5 Testing for OAuth Weaknesses">
+<li class="wstg-nav-item" data-title="4.5.5 Testing for OAuth Weaknesses" data-hints="oauth2 wstg-athz-05 athz-05">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -296,10 +296,10 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.5.5.1 Testing for OAuth Authorization Server Weaknesses">
+<li class="wstg-nav-item" data-title="4.5.5.1 Testing for OAuth Authorization Server Weaknesses" data-hints="oauth2">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05.1-Testing_for_OAuth_Authorization_Server_Weaknesses" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/05.1-Testing_for_OAuth_Authorization_Server_Weaknesses" title="4.5.5.1 Testing for OAuth Authorization Server Weaknesses">4.5.5.1 Testing for OAuth Authorization Server Weaknesses</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.5.2 Testing for OAuth Client Weaknesses">
+<li class="wstg-nav-item" data-title="4.5.5.2 Testing for OAuth Client Weaknesses" data-hints="oauth2">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/05.2-Testing_for_OAuth_Client_Weaknesses" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/05.2-Testing_for_OAuth_Client_Weaknesses" title="4.5.5.2 Testing for OAuth Client Weaknesses">4.5.5.2 Testing for OAuth Client Weaknesses</a>
 </li>
 </ul>
@@ -317,37 +317,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema">
+<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema" data-hints="wstg-sess-01 sess-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" title="4.6.1 Testing for Session Management Schema">4.6.1 Testing for Session Management Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes">
+<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes" data-hints="cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" title="4.6.2 Testing for Cookies Attributes">4.6.2 Testing for Cookies Attributes</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation">
+<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation" data-hints="wstg-sess-03 sess-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" title="4.6.3 Testing for Session Fixation">4.6.3 Testing for Session Fixation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables">
+<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables" data-hints="wstg-sess-04 sess-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" title="4.6.4 Testing for Exposed Session Variables">4.6.4 Testing for Exposed Session Variables</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery">
+<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery" data-hints="csrf xsrf wstg-sess-05 sess-05">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" title="4.6.5 Testing for Cross Site Request Forgery">4.6.5 Testing for Cross Site Request Forgery</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality">
+<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality" data-hints="wstg-sess-06 sess-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" title="4.6.6 Testing for Logout Functionality">4.6.6 Testing for Logout Functionality</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout">
+<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout" data-hints="wstg-sess-07 sess-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" title="4.6.7 Testing Session Timeout">4.6.7 Testing Session Timeout</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling">
+<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling" data-hints="wstg-sess-08 sess-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" title="4.6.8 Testing for Session Puzzling">4.6.8 Testing for Session Puzzling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.9 Testing for Session Hijacking">
+<li class="wstg-nav-item" data-title="4.6.9 Testing for Session Hijacking" data-hints="wstg-sess-09 sess-09">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking" title="4.6.9 Testing for Session Hijacking">4.6.9 Testing for Session Hijacking</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.10 Testing JSON Web Tokens">
+<li class="wstg-nav-item" data-title="4.6.10 Testing JSON Web Tokens" data-hints="jwt wstg-sess-10 sess-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens" title="4.6.10 Testing JSON Web Tokens">4.6.10 Testing JSON Web Tokens</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.11 Testing for Concurrent Sessions">
+<li class="wstg-nav-item" data-title="4.6.11 Testing for Concurrent Sessions" data-hints="wstg-sess-11 sess-11">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/11-Testing_for_Concurrent_Sessions" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/11-Testing_for_Concurrent_Sessions" title="4.6.11 Testing for Concurrent Sessions">4.6.11 Testing for Concurrent Sessions</a>
 </li>
 </ul>
@@ -362,19 +362,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting" data-hints="xss wstg-inpv-01 inpv-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" title="4.7.1 Testing for Reflected Cross Site Scripting">4.7.1 Testing for Reflected Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting" data-hints="xss wstg-inpv-02 inpv-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" title="4.7.2 Testing for Stored Cross Site Scripting">4.7.2 Testing for Stored Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering">
+<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering" data-hints="verb tampering wstg-inpv-03 inpv-03 wstg-conf-06 conf-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" title="4.7.3 Testing for HTTP Verb Tampering">4.7.3 Testing for HTTP Verb Tampering</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution">
+<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution" data-hints="hpp wstg-inpv-04 inpv-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" title="4.7.4 Testing for HTTP Parameter Pollution">4.7.4 Testing for HTTP Parameter Pollution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection" data-hints="sqli wstg-inpv-05 inpv-05">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -389,7 +389,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.2 Testing for MySQL">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" title="4.7.5.2 Testing for MySQL">4.7.5.2 Testing for MySQL</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server">
+<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server" data-hints="mssql sql server">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" title="4.7.5.3 Testing for SQL Server">4.7.5.3 Testing for SQL Server</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.4 Testing PostgreSQL">
@@ -398,7 +398,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.5 Testing for MS Access">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" title="4.7.5.5 Testing for MS Access">4.7.5.5 Testing for MS Access</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection" data-hints="sqli nosqli">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" title="4.7.5.6 Testing for NoSQL Injection">4.7.5.6 Testing for NoSQL Injection</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.7 Testing for ORM Injection">
@@ -410,22 +410,22 @@
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection">
+<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection" data-hints="ldapi wstg-inpv-06 inpv-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" title="4.7.6 Testing for LDAP Injection">4.7.6 Testing for LDAP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection">
+<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection" data-hints="xxe xmli xml injection wstg-inpv-07 inpv-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" title="4.7.7 Testing for XML Injection">4.7.7 Testing for XML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection">
+<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection" data-hints="ssi injection wstg-inpv-08 inpv-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" title="4.7.8 Testing for SSI Injection">4.7.8 Testing for SSI Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection">
+<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection" data-hints="xpathi xml wstg-inpv-09 inpv-09">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" title="4.7.9 Testing for XPath Injection">4.7.9 Testing for XPath Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection">
+<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection" data-hints="email injection wstg-inpv-10 inpv-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" title="4.7.10 Testing for IMAP SMTP Injection">4.7.10 Testing for IMAP SMTP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection">
+<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection" data-hints="rce wstg-inpv-11 inpv-11">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -434,43 +434,43 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.11.1 Testing for File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.1 Testing for File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_File_Inclusion" title="4.7.11.1 Testing for File Inclusion">4.7.11.1 Testing for File Inclusion</a>
 </li>
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection">
+<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection" data-hints="rce cmdi os command wstg-inpv-12 inpv-12">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" title="4.7.12 Testing for Command Injection">4.7.12 Testing for Command Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.13 Testing for Format String Injection">
+<li class="wstg-nav-item" data-title="4.7.13 Testing for Format String Injection" data-hints="format string bug wstg-inpv-13 inpv-13">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection" title="4.7.13 Testing for Format String Injection">4.7.13 Testing for Format String Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability">
+<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability" data-hints="wstg-inpv-14 inpv-14">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" title="4.7.14 Testing for Incubated Vulnerability">4.7.14 Testing for Incubated Vulnerability</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Response Splitting">
+<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Response Splitting" data-hints="crlf response splitting wstg-inpv-15 inpv-15">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Response_Splitting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Response_Splitting" title="4.7.15 Testing for HTTP Response Splitting">4.7.15 Testing for HTTP Response Splitting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Request Smuggling">
+<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Request Smuggling" data-hints="http smuggling wstg-inpv-16 inpv-16">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Request_Smuggling" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Request_Smuggling" title="4.7.16 Testing for HTTP Request Smuggling">4.7.16 Testing for HTTP Request Smuggling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection">
+<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection" data-hints="host header injection headers wstg-inpv-17 inpv-17">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" title="4.7.17 Testing for Host Header Injection">4.7.17 Testing for Host Header Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.18 Testing for Server-side Template Injection">
+<li class="wstg-nav-item" data-title="4.7.18 Testing for Server-side Template Injection" data-hints="ssti wstg-inpv-18 inpv-18">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection" title="4.7.18 Testing for Server-side Template Injection">4.7.18 Testing for Server-side Template Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.19 Testing for Server-Side Request Forgery">
+<li class="wstg-nav-item" data-title="4.7.19 Testing for Server-Side Request Forgery" data-hints="ssrf wstg-inpv-19 inpv-19">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery" title="4.7.19 Testing for Server-Side Request Forgery">4.7.19 Testing for Server-Side Request Forgery</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.20 Testing for Mass Assignment">
+<li class="wstg-nav-item" data-title="4.7.20 Testing for Mass Assignment" data-hints="mass assign wstg-inpv-20 inpv-20">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/20-Testing_for_Mass_Assignment" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/20-Testing_for_Mass_Assignment" title="4.7.20 Testing for Mass Assignment">4.7.20 Testing for Mass Assignment</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.21 Testing for CSV Injection">
+<li class="wstg-nav-item" data-title="4.7.21 Testing for CSV Injection" data-hints="formula injection wstg-inpv-21 inpv-21">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/21-Testing_for_CSV_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/21-Testing_for_CSV_Injection" title="4.7.21 Testing for CSV Injection">4.7.21 Testing for CSV Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.22 Testing for Prototype Pollution">
+<li class="wstg-nav-item" data-title="4.7.22 Testing for Prototype Pollution" data-hints="pp wstg-inpv-22 inpv-22">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/22-Testing_for_Prototype_Pollution" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/22-Testing_for_Prototype_Pollution" title="4.7.22 Testing for Prototype Pollution">4.7.22 Testing for Prototype Pollution</a>
 </li>
 </ul>
@@ -485,10 +485,10 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.8.1 Testing for Improper Error Handling">
+<li class="wstg-nav-item" data-title="4.8.1 Testing for Improper Error Handling" data-hints="wstg-errh-01 errh-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling" title="4.8.1 Testing for Improper Error Handling">4.8.1 Testing for Improper Error Handling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces">
+<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces" data-hints="wstg-errh-02 errh-02 wstg-errh-01 errh-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" title="4.8.2 Testing for Stack Traces">4.8.2 Testing for Stack Traces</a>
 </li>
 </ul>
@@ -503,16 +503,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak Transport Layer Security">
+<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak Transport Layer Security" data-hints="tls ssl https wstg-cryp-01 cryp-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security" title="4.9.1 Testing for Weak Transport Layer Security">4.9.1 Testing for Weak Transport Layer Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle">
+<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle" data-hints="padding oracle attack wstg-cryp-02 cryp-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" title="4.9.2 Testing for Padding Oracle">4.9.2 Testing for Padding Oracle</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">
+<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels" data-hints="tls ssl https cleartext wstg-cryp-03 cryp-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Cryptographic Primitives">
+<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Cryptographic Primitives" data-hints="wstg-cryp-04 cryp-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Cryptographic_Primitives" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Cryptographic_Primitives" title="4.9.4 Testing for Weak Cryptographic Primitives">4.9.4 Testing for Weak Cryptographic Primitives</a>
 </li>
 </ul>
@@ -530,34 +530,34 @@
 <li class="wstg-nav-item" data-title="4.10.0 Introduction to Business Logic">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" title="4.10.0 Introduction to Business Logic">4.10.0 Introduction to Business Logic</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation">
+<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation" data-hints="wstg-busl-01 busl-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" title="4.10.1 Test Business Logic Data Validation">4.10.1 Test Business Logic Data Validation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests">
+<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests" data-hints="wstg-busl-02 busl-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" title="4.10.2 Test Ability to Forge Requests">4.10.2 Test Ability to Forge Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks">
+<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks" data-hints="wstg-busl-03 busl-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" title="4.10.3 Test Integrity Checks">4.10.3 Test Integrity Checks</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing">
+<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing" data-hints="race condition toctou wstg-busl-04 busl-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" title="4.10.4 Test for Process Timing">4.10.4 Test for Process Timing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits">
+<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits" data-hints="rate limit bruteforce brute force wstg-busl-05 busl-05">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" title="4.10.5 Test Number of Times a Function Can Be Used Limits">4.10.5 Test Number of Times a Function Can Be Used Limits</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows">
+<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows" data-hints="wstg-busl-06 busl-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" title="4.10.6 Testing for the Circumvention of Work Flows">4.10.6 Testing for the Circumvention of Work Flows</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse">
+<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse" data-hints="wstg-busl-07 busl-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" title="4.10.7 Test Defenses Against Application Misuse">4.10.7 Test Defenses Against Application Misuse</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types">
+<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types" data-hints="wstg-busl-08 busl-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" title="4.10.8 Test Upload of Unexpected File Types">4.10.8 Test Upload of Unexpected File Types</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files">
+<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files" data-hints="wstg-busl-09 busl-09">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" title="4.10.9 Test Upload of Malicious Files">4.10.9 Test Upload of Malicious Files</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.10 Test Payment Functionality">
+<li class="wstg-nav-item" data-title="4.10.10 Test Payment Functionality" data-hints="wstg-busl-10 busl-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/10-Business_Logic_Testing/10-Test-Payment-Functionality" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/10-Test-Payment-Functionality" title="4.10.10 Test Payment Functionality">4.10.10 Test Payment Functionality</a>
 </li>
 </ul>
@@ -572,7 +572,7 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting" data-hints="xss dom xss domxss wstg-clnt-01 clnt-01">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -581,52 +581,52 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.11.1.1 Testing for Self DOM Based Cross-Site Scripting">
+<li class="wstg-nav-item" data-title="4.11.1.1 Testing for Self DOM Based Cross-Site Scripting" data-hints="xss dom xss domxss">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/01.1-Testing_for_Self_DOM_Based_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/01.1-Testing_for_Self_DOM_Based_Cross_Site_Scripting" title="4.11.1.1 Testing for Self DOM Based Cross-Site Scripting">4.11.1.1 Testing for Self DOM Based Cross-Site Scripting</a>
 </li>
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution">
+<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution" data-hints="wstg-clnt-02 clnt-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution" title="4.11.2 Testing for JavaScript Execution">4.11.2 Testing for JavaScript Execution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection">
+<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection" data-hints="wstg-clnt-03 clnt-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection" title="4.11.3 Testing for HTML Injection">4.11.3 Testing for HTML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.4 Testing for Client-side URL Redirect">
+<li class="wstg-nav-item" data-title="4.11.4 Testing for Client-side URL Redirect" data-hints="open redirect wstg-clnt-04 clnt-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect" title="4.11.4 Testing for Client-side URL Redirect">4.11.4 Testing for Client-side URL Redirect</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection">
+<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection" data-hints="wstg-clnt-05 clnt-05">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection" title="4.11.5 Testing for CSS Injection">4.11.5 Testing for CSS Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.6 Testing for Client-side Resource Manipulation">
+<li class="wstg-nav-item" data-title="4.11.6 Testing for Client-side Resource Manipulation" data-hints="wstg-clnt-06 clnt-06">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation" title="4.11.6 Testing for Client-side Resource Manipulation">4.11.6 Testing for Client-side Resource Manipulation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing">
+<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing" data-hints="cors headers wstg-clnt-07 clnt-07">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing" title="4.11.7 Testing Cross Origin Resource Sharing">4.11.7 Testing Cross Origin Resource Sharing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing">
+<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing" data-hints="wstg-clnt-08 clnt-08">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing" title="4.11.8 Testing for Cross Site Flashing">4.11.8 Testing for Cross Site Flashing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking">
+<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking" data-hints="ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking" title="4.11.9 Testing for Clickjacking">4.11.9 Testing for Clickjacking</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets">
+<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets" data-hints="ws wstg-clnt-10 clnt-10">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets" title="4.11.10 Testing WebSockets">4.11.10 Testing WebSockets</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging">
+<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging" data-hints="postmessage post message wstg-clnt-11 clnt-11">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging" title="4.11.11 Testing Web Messaging">4.11.11 Testing Web Messaging</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage">
+<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage" data-hints="localstorage sessionstorage wstg-clnt-12 clnt-12">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage" title="4.11.12 Testing Browser Storage">4.11.12 Testing Browser Storage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion">
+<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion" data-hints="xssi wstg-clnt-13 clnt-13">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" title="4.11.13 Testing for Cross Site Script Inclusion">4.11.13 Testing for Cross Site Script Inclusion</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.14 Testing for Reverse Tabnabbing">
+<li class="wstg-nav-item" data-title="4.11.14 Testing for Reverse Tabnabbing" data-hints="tabnabbing window.opener wstg-clnt-14 clnt-14">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/14-Testing_for_Reverse_Tabnabbing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/14-Testing_for_Reverse_Tabnabbing" title="4.11.14 Testing for Reverse Tabnabbing">4.11.14 Testing for Reverse Tabnabbing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.15 Testing for Client-side Template Injection">
+<li class="wstg-nav-item" data-title="4.11.15 Testing for Client-side Template Injection" data-hints="csti wstg-clnt-15 clnt-15">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/15-Testing_for_Client-Side_Template_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/15-Testing_for_Client-Side_Template_Injection" title="4.11.15 Testing for Client-side Template Injection">4.11.15 Testing for Client-side Template Injection</a>
 </li>
 </ul>
@@ -644,19 +644,19 @@
 <li class="wstg-nav-item" data-title="4.12.0 API Testing Overview">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/12-API_Testing/00-API_Testing_Overview" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/00-API_Testing_Overview" title="4.12.0 API Testing Overview">4.12.0 API Testing Overview</a>
 </li>
-<li class="wstg-nav-item" data-title="4.12.1 API Reconnaissance">
+<li class="wstg-nav-item" data-title="4.12.1 API Reconnaissance" data-hints="wstg-apit-01 apit-01">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/01-API_Reconnaissance" title="4.12.1 API Reconnaissance">4.12.1 API Reconnaissance</a>
 </li>
-<li class="wstg-nav-item" data-title="4.12.2 API Broken Object Level Authorization">
+<li class="wstg-nav-item" data-title="4.12.2 API Broken Object Level Authorization" data-hints="bola idor wstg-apit-02 apit-02">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/12-API_Testing/02-API_Broken_Object_Level_Authorization" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/02-API_Broken_Object_Level_Authorization" title="4.12.2 API Broken Object Level Authorization">4.12.2 API Broken Object Level Authorization</a>
 </li>
-<li class="wstg-nav-item" data-title="4.12.3 Testing for Excessive Data Exposure">
+<li class="wstg-nav-item" data-title="4.12.3 Testing for Excessive Data Exposure" data-hints="wstg-apit-03 apit-03">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/12-API_Testing/03-Testing_for_Excessive_Data_Exposure" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/03-Testing_for_Excessive_Data_Exposure" title="4.12.3 Testing for Excessive Data Exposure">4.12.3 Testing for Excessive Data Exposure</a>
 </li>
-<li class="wstg-nav-item" data-title="4.12.4 API Broken Function Level Authorization">
+<li class="wstg-nav-item" data-title="4.12.4 API Broken Function Level Authorization" data-hints="bfla wstg-apit-04 apit-04">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/12-API_Testing/04-API_Broken_Function_Level_Authorization" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/04-API_Broken_Function_Level_Authorization" title="4.12.4 API Broken Function Level Authorization">4.12.4 API Broken Function Level Authorization</a>
 </li>
-<li class="wstg-nav-item" data-title="4.12.99 Testing GraphQL">
+<li class="wstg-nav-item" data-title="4.12.99 Testing GraphQL" data-hints="gql wstg-apit-99 apit-99">
 <a href="{{ site.baseurl }}/latest/4-Web_Application_Security_Testing/12-API_Testing/99-Testing_GraphQL" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/99-Testing_GraphQL" title="4.12.99 Testing GraphQL">4.12.99 Testing GraphQL</a>
 </li>
 </ul>

--- a/_includes/nav-tree-stable.html
+++ b/_includes/nav-tree-stable.html
@@ -107,34 +107,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage" data-hints="wstg-info-01 info-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server">
+<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server" data-hints="wstg-info-02 info-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" title="4.1.2 Fingerprint Web Server">4.1.2 Fingerprint Web Server</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage" data-hints="robots robots.txt sitemap sitemap.xml wstg-info-03 info-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" title="4.1.3 Review Webserver Metafiles for Information Leakage">4.1.3 Review Webserver Metafiles for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.4 Enumerate Applications on Webserver">
+<li class="wstg-nav-item" data-title="4.1.4 Enumerate Applications on Webserver" data-hints="wstg-info-04 info-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver" title="4.1.4 Enumerate Applications on Webserver">4.1.4 Enumerate Applications on Webserver</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.5 Review Webpage Content for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.5 Review Webpage Content for Information Leakage" data-hints="wstg-info-05 info-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage" title="4.1.5 Review Webpage Content for Information Leakage">4.1.5 Review Webpage Content for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points">
+<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points" data-hints="wstg-info-06 info-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" title="4.1.6 Identify Application Entry Points">4.1.6 Identify Application Entry Points</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application">
+<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application" data-hints="wstg-info-07 info-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" title="4.1.7 Map Execution Paths Through Application">4.1.7 Map Execution Paths Through Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework">
+<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework" data-hints="wstg-info-08 info-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" title="4.1.8 Fingerprint Web Application Framework">4.1.8 Fingerprint Web Application Framework</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application">
+<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application" data-hints="wstg-info-09 info-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" title="4.1.9 Fingerprint Web Application">4.1.9 Fingerprint Web Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture">
+<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture" data-hints="wstg-info-10 info-10">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" title="4.1.10 Map Application Architecture">4.1.10 Map Application Architecture</a>
 </li>
 </ul>
@@ -149,37 +149,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration">
+<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration" data-hints="wstg-conf-01 conf-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" title="4.2.1 Test Network Infrastructure Configuration">4.2.1 Test Network Infrastructure Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration">
+<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration" data-hints="wstg-conf-02 conf-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" title="4.2.2 Test Application Platform Configuration">4.2.2 Test Application Platform Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information" data-hints="wstg-conf-03 conf-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" title="4.2.3 Test File Extensions Handling for Sensitive Information">4.2.3 Test File Extensions Handling for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information" data-hints="wstg-conf-04 conf-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">
+<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces" data-hints="wstg-conf-05 conf-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">4.2.5 Enumerate Infrastructure and Application Admin Interfaces</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods">
+<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods" data-hints="wstg-conf-06 conf-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" title="4.2.6 Test HTTP Methods">4.2.6 Test HTTP Methods</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security">
+<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security" data-hints="hsts headers wstg-conf-07 conf-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" title="4.2.7 Test HTTP Strict Transport Security">4.2.7 Test HTTP Strict Transport Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy">
+<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy" data-hints="crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" title="4.2.8 Test RIA Cross Domain Policy">4.2.8 Test RIA Cross Domain Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.9 Test File Permission">
+<li class="wstg-nav-item" data-title="4.2.9 Test File Permission" data-hints="wstg-conf-09 conf-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" title="4.2.9 Test File Permission">4.2.9 Test File Permission</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover">
+<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover" data-hints="wstg-conf-10 conf-10">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" title="4.2.10 Test for Subdomain Takeover">4.2.10 Test for Subdomain Takeover</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage">
+<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage" data-hints="s3 bucket blob storage wstg-conf-11 conf-11">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" title="4.2.11 Test Cloud Storage">4.2.11 Test Cloud Storage</a>
 </li>
 </ul>
@@ -194,19 +194,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions">
+<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions" data-hints="wstg-idnt-01 idnt-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" title="4.3.1 Test Role Definitions">4.3.1 Test Role Definitions</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process">
+<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process" data-hints="wstg-idnt-02 idnt-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" title="4.3.2 Test User Registration Process">4.3.2 Test User Registration Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process">
+<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process" data-hints="wstg-idnt-03 idnt-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" title="4.3.3 Test Account Provisioning Process">4.3.3 Test Account Provisioning Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account">
+<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account" data-hints="wstg-idnt-04 idnt-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" title="4.3.4 Testing for Account Enumeration and Guessable User Account">4.3.4 Testing for Account Enumeration and Guessable User Account</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy">
+<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy" data-hints="wstg-idnt-05 idnt-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" title="4.3.5 Testing for Weak or Unenforced Username Policy">4.3.5 Testing for Weak or Unenforced Username Policy</a>
 </li>
 </ul>
@@ -221,34 +221,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">
+<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel" data-hints="tls ssl https wstg-athn-01 athn-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">4.4.1 Testing for Credentials Transported over an Encrypted Channel</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials">
+<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials" data-hints="wstg-athn-02 athn-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" title="4.4.2 Testing for Default Credentials">4.4.2 Testing for Default Credentials</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism">
+<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism" data-hints="rate limit bruteforce brute force account lockout wstg-athn-03 athn-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" title="4.4.3 Testing for Weak Lock Out Mechanism">4.4.3 Testing for Weak Lock Out Mechanism</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema">
+<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema" data-hints="wstg-athn-04 athn-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" title="4.4.4 Testing for Bypassing Authentication Schema">4.4.4 Testing for Bypassing Authentication Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password">
+<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password" data-hints="wstg-athn-05 athn-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" title="4.4.5 Testing for Vulnerable Remember Password">4.4.5 Testing for Vulnerable Remember Password</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses">
+<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses" data-hints="wstg-athn-06 athn-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" title="4.4.6 Testing for Browser Cache Weaknesses">4.4.6 Testing for Browser Cache Weaknesses</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Password Policy">
+<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Password Policy" data-hints="wstg-athn-07 athn-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy" title="4.4.7 Testing for Weak Password Policy">4.4.7 Testing for Weak Password Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer">
+<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer" data-hints="wstg-athn-08 athn-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" title="4.4.8 Testing for Weak Security Question Answer">4.4.8 Testing for Weak Security Question Answer</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities">
+<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities" data-hints="wstg-athn-09 athn-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" title="4.4.9 Testing for Weak Password Change or Reset Functionalities">4.4.9 Testing for Weak Password Change or Reset Functionalities</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel">
+<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel" data-hints="wstg-athn-10 athn-10">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" title="4.4.10 Testing for Weaker Authentication in Alternative Channel">4.4.10 Testing for Weaker Authentication in Alternative Channel</a>
 </li>
 </ul>
@@ -263,16 +263,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include">
+<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include" data-hints="path traversal dotdot lfi wstg-athz-01 athz-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" title="4.5.1 Testing Directory Traversal File Include">4.5.1 Testing Directory Traversal File Include</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema">
+<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema" data-hints="wstg-athz-02 athz-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" title="4.5.2 Testing for Bypassing Authorization Schema">4.5.2 Testing for Bypassing Authorization Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation">
+<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation" data-hints="privesc wstg-athz-03 athz-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" title="4.5.3 Testing for Privilege Escalation">4.5.3 Testing for Privilege Escalation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References">
+<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References" data-hints="idor wstg-athz-04 athz-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" title="4.5.4 Testing for Insecure Direct Object References">4.5.4 Testing for Insecure Direct Object References</a>
 </li>
 </ul>
@@ -287,31 +287,31 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema">
+<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema" data-hints="wstg-sess-01 sess-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" title="4.6.1 Testing for Session Management Schema">4.6.1 Testing for Session Management Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes">
+<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes" data-hints="cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" title="4.6.2 Testing for Cookies Attributes">4.6.2 Testing for Cookies Attributes</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation">
+<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation" data-hints="wstg-sess-03 sess-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" title="4.6.3 Testing for Session Fixation">4.6.3 Testing for Session Fixation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables">
+<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables" data-hints="wstg-sess-04 sess-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" title="4.6.4 Testing for Exposed Session Variables">4.6.4 Testing for Exposed Session Variables</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery">
+<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery" data-hints="csrf xsrf wstg-sess-05 sess-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" title="4.6.5 Testing for Cross Site Request Forgery">4.6.5 Testing for Cross Site Request Forgery</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality">
+<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality" data-hints="wstg-sess-06 sess-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" title="4.6.6 Testing for Logout Functionality">4.6.6 Testing for Logout Functionality</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout">
+<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout" data-hints="wstg-sess-07 sess-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" title="4.6.7 Testing Session Timeout">4.6.7 Testing Session Timeout</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling">
+<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling" data-hints="wstg-sess-08 sess-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" title="4.6.8 Testing for Session Puzzling">4.6.8 Testing for Session Puzzling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.9 Testing for Session Hijacking">
+<li class="wstg-nav-item" data-title="4.6.9 Testing for Session Hijacking" data-hints="wstg-sess-09 sess-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking" title="4.6.9 Testing for Session Hijacking">4.6.9 Testing for Session Hijacking</a>
 </li>
 </ul>
@@ -326,19 +326,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting" data-hints="xss wstg-inpv-01 inpv-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" title="4.7.1 Testing for Reflected Cross Site Scripting">4.7.1 Testing for Reflected Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting" data-hints="xss wstg-inpv-02 inpv-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" title="4.7.2 Testing for Stored Cross Site Scripting">4.7.2 Testing for Stored Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering">
+<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering" data-hints="verb tampering wstg-inpv-03 inpv-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" title="4.7.3 Testing for HTTP Verb Tampering">4.7.3 Testing for HTTP Verb Tampering</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution">
+<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution" data-hints="hpp wstg-inpv-04 inpv-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" title="4.7.4 Testing for HTTP Parameter Pollution">4.7.4 Testing for HTTP Parameter Pollution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection" data-hints="sqli wstg-inpv-05 inpv-05">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -353,7 +353,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.2 Testing for MySQL">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" title="4.7.5.2 Testing for MySQL">4.7.5.2 Testing for MySQL</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server">
+<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server" data-hints="mssql sql server">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" title="4.7.5.3 Testing for SQL Server">4.7.5.3 Testing for SQL Server</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.4 Testing PostgreSQL">
@@ -362,7 +362,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.5 Testing for MS Access">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" title="4.7.5.5 Testing for MS Access">4.7.5.5 Testing for MS Access</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection" data-hints="sqli nosqli">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" title="4.7.5.6 Testing for NoSQL Injection">4.7.5.6 Testing for NoSQL Injection</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.7 Testing for ORM Injection">
@@ -374,22 +374,22 @@
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection">
+<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection" data-hints="ldapi wstg-inpv-06 inpv-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" title="4.7.6 Testing for LDAP Injection">4.7.6 Testing for LDAP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection">
+<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection" data-hints="xxe xmli xml injection wstg-inpv-07 inpv-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" title="4.7.7 Testing for XML Injection">4.7.7 Testing for XML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection">
+<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection" data-hints="ssi injection wstg-inpv-08 inpv-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" title="4.7.8 Testing for SSI Injection">4.7.8 Testing for SSI Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection">
+<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection" data-hints="xpathi xml wstg-inpv-09 inpv-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" title="4.7.9 Testing for XPath Injection">4.7.9 Testing for XPath Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection">
+<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection" data-hints="email injection wstg-inpv-10 inpv-10">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" title="4.7.10 Testing for IMAP SMTP Injection">4.7.10 Testing for IMAP SMTP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection">
+<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection" data-hints="rce wstg-inpv-11 inpv-11">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -398,37 +398,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.11.1 Testing for Local File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.1 Testing for Local File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion" title="4.7.11.1 Testing for Local File Inclusion">4.7.11.1 Testing for Local File Inclusion</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11.2 Testing for Remote File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.2 Testing for Remote File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion" title="4.7.11.2 Testing for Remote File Inclusion">4.7.11.2 Testing for Remote File Inclusion</a>
 </li>
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection">
+<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection" data-hints="rce cmdi os command wstg-inpv-12 inpv-12">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" title="4.7.12 Testing for Command Injection">4.7.12 Testing for Command Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.13 Testing for Format String Injection">
+<li class="wstg-nav-item" data-title="4.7.13 Testing for Format String Injection" data-hints="format string bug wstg-inpv-13 inpv-13">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection" title="4.7.13 Testing for Format String Injection">4.7.13 Testing for Format String Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability">
+<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability" data-hints="wstg-inpv-14 inpv-14">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" title="4.7.14 Testing for Incubated Vulnerability">4.7.14 Testing for Incubated Vulnerability</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Splitting Smuggling">
+<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Splitting Smuggling" data-hints="wstg-inpv-15 inpv-15">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling" title="4.7.15 Testing for HTTP Splitting Smuggling">4.7.15 Testing for HTTP Splitting Smuggling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Incoming Requests">
+<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Incoming Requests" data-hints="wstg-inpv-16 inpv-16">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests" title="4.7.16 Testing for HTTP Incoming Requests">4.7.16 Testing for HTTP Incoming Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection">
+<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection" data-hints="host header injection headers wstg-inpv-17 inpv-17">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" title="4.7.17 Testing for Host Header Injection">4.7.17 Testing for Host Header Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.18 Testing for Server-side Template Injection">
+<li class="wstg-nav-item" data-title="4.7.18 Testing for Server-side Template Injection" data-hints="ssti wstg-inpv-18 inpv-18">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection" title="4.7.18 Testing for Server-side Template Injection">4.7.18 Testing for Server-side Template Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.19 Testing for Server-Side Request Forgery">
+<li class="wstg-nav-item" data-title="4.7.19 Testing for Server-Side Request Forgery" data-hints="ssrf wstg-inpv-19 inpv-19">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery" title="4.7.19 Testing for Server-Side Request Forgery">4.7.19 Testing for Server-Side Request Forgery</a>
 </li>
 </ul>
@@ -443,10 +443,10 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.8.1 Testing for Improper Error Handling">
+<li class="wstg-nav-item" data-title="4.8.1 Testing for Improper Error Handling" data-hints="wstg-errh-01 errh-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling" title="4.8.1 Testing for Improper Error Handling">4.8.1 Testing for Improper Error Handling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces">
+<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces" data-hints="wstg-errh-02 errh-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" title="4.8.2 Testing for Stack Traces">4.8.2 Testing for Stack Traces</a>
 </li>
 </ul>
@@ -461,16 +461,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak Transport Layer Security">
+<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak Transport Layer Security" data-hints="tls ssl https wstg-cryp-01 cryp-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security" title="4.9.1 Testing for Weak Transport Layer Security">4.9.1 Testing for Weak Transport Layer Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle">
+<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle" data-hints="padding oracle attack wstg-cryp-02 cryp-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" title="4.9.2 Testing for Padding Oracle">4.9.2 Testing for Padding Oracle</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">
+<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels" data-hints="tls ssl https cleartext wstg-cryp-03 cryp-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Encryption">
+<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Encryption" data-hints="wstg-cryp-04 cryp-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption" title="4.9.4 Testing for Weak Encryption">4.9.4 Testing for Weak Encryption</a>
 </li>
 </ul>
@@ -488,31 +488,31 @@
 <li class="wstg-nav-item" data-title="4.10.0 Introduction to Business Logic">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" title="4.10.0 Introduction to Business Logic">4.10.0 Introduction to Business Logic</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation">
+<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation" data-hints="wstg-busl-01 busl-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" title="4.10.1 Test Business Logic Data Validation">4.10.1 Test Business Logic Data Validation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests">
+<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests" data-hints="wstg-busl-02 busl-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" title="4.10.2 Test Ability to Forge Requests">4.10.2 Test Ability to Forge Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks">
+<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks" data-hints="wstg-busl-03 busl-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" title="4.10.3 Test Integrity Checks">4.10.3 Test Integrity Checks</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing">
+<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing" data-hints="race condition toctou wstg-busl-04 busl-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" title="4.10.4 Test for Process Timing">4.10.4 Test for Process Timing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits">
+<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits" data-hints="rate limit bruteforce brute force wstg-busl-05 busl-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" title="4.10.5 Test Number of Times a Function Can Be Used Limits">4.10.5 Test Number of Times a Function Can Be Used Limits</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows">
+<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows" data-hints="wstg-busl-06 busl-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" title="4.10.6 Testing for the Circumvention of Work Flows">4.10.6 Testing for the Circumvention of Work Flows</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse">
+<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse" data-hints="wstg-busl-07 busl-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" title="4.10.7 Test Defenses Against Application Misuse">4.10.7 Test Defenses Against Application Misuse</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types">
+<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types" data-hints="wstg-busl-08 busl-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" title="4.10.8 Test Upload of Unexpected File Types">4.10.8 Test Upload of Unexpected File Types</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files">
+<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files" data-hints="wstg-busl-09 busl-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" title="4.10.9 Test Upload of Malicious Files">4.10.9 Test Upload of Malicious Files</a>
 </li>
 </ul>
@@ -527,43 +527,43 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting" data-hints="xss dom xss domxss wstg-clnt-01 clnt-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting" title="4.11.1 Testing for DOM-Based Cross Site Scripting">4.11.1 Testing for DOM-Based Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution">
+<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution" data-hints="wstg-clnt-02 clnt-02">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution" title="4.11.2 Testing for JavaScript Execution">4.11.2 Testing for JavaScript Execution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection">
+<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection" data-hints="wstg-clnt-03 clnt-03">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection" title="4.11.3 Testing for HTML Injection">4.11.3 Testing for HTML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.4 Testing for Client-side URL Redirect">
+<li class="wstg-nav-item" data-title="4.11.4 Testing for Client-side URL Redirect" data-hints="open redirect wstg-clnt-04 clnt-04">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect" title="4.11.4 Testing for Client-side URL Redirect">4.11.4 Testing for Client-side URL Redirect</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection">
+<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection" data-hints="wstg-clnt-05 clnt-05">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection" title="4.11.5 Testing for CSS Injection">4.11.5 Testing for CSS Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.6 Testing for Client-side Resource Manipulation">
+<li class="wstg-nav-item" data-title="4.11.6 Testing for Client-side Resource Manipulation" data-hints="wstg-clnt-06 clnt-06">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation" title="4.11.6 Testing for Client-side Resource Manipulation">4.11.6 Testing for Client-side Resource Manipulation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing">
+<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing" data-hints="cors headers wstg-clnt-07 clnt-07">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing" title="4.11.7 Testing Cross Origin Resource Sharing">4.11.7 Testing Cross Origin Resource Sharing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing">
+<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing" data-hints="wstg-clnt-08 clnt-08">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing" title="4.11.8 Testing for Cross Site Flashing">4.11.8 Testing for Cross Site Flashing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking">
+<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking" data-hints="ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking" title="4.11.9 Testing for Clickjacking">4.11.9 Testing for Clickjacking</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets">
+<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets" data-hints="ws wstg-clnt-10 clnt-10">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets" title="4.11.10 Testing WebSockets">4.11.10 Testing WebSockets</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging">
+<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging" data-hints="postmessage post message wstg-clnt-11 clnt-11">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging" title="4.11.11 Testing Web Messaging">4.11.11 Testing Web Messaging</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage">
+<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage" data-hints="localstorage sessionstorage wstg-clnt-12 clnt-12">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage" title="4.11.12 Testing Browser Storage">4.11.12 Testing Browser Storage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion">
+<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion" data-hints="xssi wstg-clnt-13 clnt-13">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" title="4.11.13 Testing for Cross Site Script Inclusion">4.11.13 Testing for Cross Site Script Inclusion</a>
 </li>
 </ul>
@@ -578,7 +578,7 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.12.1 Testing GraphQL">
+<li class="wstg-nav-item" data-title="4.12.1 Testing GraphQL" data-hints="gql wstg-apit-01 apit-01">
 <a href="{{ site.baseurl }}/stable/4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL" title="4.12.1 Testing GraphQL">4.12.1 Testing GraphQL</a>
 </li>
 </ul>

--- a/_includes/nav-tree-v41.html
+++ b/_includes/nav-tree-v41.html
@@ -107,34 +107,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage" data-hints="wstg-info-01 info-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server">
+<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server" data-hints="wstg-info-02 info-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" title="4.1.2 Fingerprint Web Server">4.1.2 Fingerprint Web Server</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage" data-hints="robots robots.txt sitemap sitemap.xml wstg-info-03 info-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" title="4.1.3 Review Webserver Metafiles for Information Leakage">4.1.3 Review Webserver Metafiles for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.4 Enumerate Applications on Webserver">
+<li class="wstg-nav-item" data-title="4.1.4 Enumerate Applications on Webserver" data-hints="wstg-info-04 info-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver" title="4.1.4 Enumerate Applications on Webserver">4.1.4 Enumerate Applications on Webserver</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.5 Review Webpage Comments and Metadata for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.5 Review Webpage Comments and Metadata for Information Leakage" data-hints="wstg-info-05 info-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Comments_and_Metadata_for_Information_Leakage" title="4.1.5 Review Webpage Comments and Metadata for Information Leakage">4.1.5 Review Webpage Comments and Metadata for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points">
+<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points" data-hints="wstg-info-06 info-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" title="4.1.6 Identify Application Entry Points">4.1.6 Identify Application Entry Points</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application">
+<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application" data-hints="wstg-info-07 info-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" title="4.1.7 Map Execution Paths Through Application">4.1.7 Map Execution Paths Through Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework">
+<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework" data-hints="wstg-info-08 info-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" title="4.1.8 Fingerprint Web Application Framework">4.1.8 Fingerprint Web Application Framework</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application">
+<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application" data-hints="wstg-info-09 info-09">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" title="4.1.9 Fingerprint Web Application">4.1.9 Fingerprint Web Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture">
+<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture" data-hints="wstg-info-10 info-10">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" title="4.1.10 Map Application Architecture">4.1.10 Map Application Architecture</a>
 </li>
 </ul>
@@ -149,37 +149,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration">
+<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration" data-hints="wstg-conf-01 conf-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" title="4.2.1 Test Network Infrastructure Configuration">4.2.1 Test Network Infrastructure Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration">
+<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration" data-hints="wstg-conf-02 conf-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" title="4.2.2 Test Application Platform Configuration">4.2.2 Test Application Platform Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information" data-hints="wstg-conf-03 conf-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" title="4.2.3 Test File Extensions Handling for Sensitive Information">4.2.3 Test File Extensions Handling for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information" data-hints="wstg-conf-04 conf-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">
+<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces" data-hints="wstg-conf-05 conf-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">4.2.5 Enumerate Infrastructure and Application Admin Interfaces</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods">
+<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods" data-hints="wstg-conf-06 conf-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" title="4.2.6 Test HTTP Methods">4.2.6 Test HTTP Methods</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security">
+<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security" data-hints="hsts headers wstg-conf-07 conf-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" title="4.2.7 Test HTTP Strict Transport Security">4.2.7 Test HTTP Strict Transport Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy">
+<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy" data-hints="crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" title="4.2.8 Test RIA Cross Domain Policy">4.2.8 Test RIA Cross Domain Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.9 Test File Permission">
+<li class="wstg-nav-item" data-title="4.2.9 Test File Permission" data-hints="wstg-conf-09 conf-09">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" title="4.2.9 Test File Permission">4.2.9 Test File Permission</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover">
+<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover" data-hints="wstg-conf-10 conf-10">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" title="4.2.10 Test for Subdomain Takeover">4.2.10 Test for Subdomain Takeover</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage">
+<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage" data-hints="s3 bucket blob storage wstg-conf-11 conf-11">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" title="4.2.11 Test Cloud Storage">4.2.11 Test Cloud Storage</a>
 </li>
 </ul>
@@ -194,19 +194,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions">
+<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions" data-hints="wstg-idnt-01 idnt-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" title="4.3.1 Test Role Definitions">4.3.1 Test Role Definitions</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process">
+<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process" data-hints="wstg-idnt-02 idnt-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" title="4.3.2 Test User Registration Process">4.3.2 Test User Registration Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process">
+<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process" data-hints="wstg-idnt-03 idnt-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" title="4.3.3 Test Account Provisioning Process">4.3.3 Test Account Provisioning Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account">
+<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account" data-hints="wstg-idnt-04 idnt-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" title="4.3.4 Testing for Account Enumeration and Guessable User Account">4.3.4 Testing for Account Enumeration and Guessable User Account</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy">
+<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy" data-hints="wstg-idnt-05 idnt-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" title="4.3.5 Testing for Weak or Unenforced Username Policy">4.3.5 Testing for Weak or Unenforced Username Policy</a>
 </li>
 </ul>
@@ -221,34 +221,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">
+<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel" data-hints="tls ssl https wstg-athn-01 athn-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">4.4.1 Testing for Credentials Transported over an Encrypted Channel</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials">
+<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials" data-hints="wstg-athn-02 athn-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" title="4.4.2 Testing for Default Credentials">4.4.2 Testing for Default Credentials</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism">
+<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism" data-hints="rate limit bruteforce brute force account lockout wstg-athn-03 athn-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" title="4.4.3 Testing for Weak Lock Out Mechanism">4.4.3 Testing for Weak Lock Out Mechanism</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema">
+<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema" data-hints="wstg-athn-04 athn-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" title="4.4.4 Testing for Bypassing Authentication Schema">4.4.4 Testing for Bypassing Authentication Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password">
+<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password" data-hints="wstg-athn-05 athn-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" title="4.4.5 Testing for Vulnerable Remember Password">4.4.5 Testing for Vulnerable Remember Password</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses">
+<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses" data-hints="wstg-athn-06 athn-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" title="4.4.6 Testing for Browser Cache Weaknesses">4.4.6 Testing for Browser Cache Weaknesses</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Password Policy">
+<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Password Policy" data-hints="wstg-athn-07 athn-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy" title="4.4.7 Testing for Weak Password Policy">4.4.7 Testing for Weak Password Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer">
+<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer" data-hints="wstg-athn-08 athn-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" title="4.4.8 Testing for Weak Security Question Answer">4.4.8 Testing for Weak Security Question Answer</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities">
+<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities" data-hints="wstg-athn-09 athn-09">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" title="4.4.9 Testing for Weak Password Change or Reset Functionalities">4.4.9 Testing for Weak Password Change or Reset Functionalities</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel">
+<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel" data-hints="wstg-athn-10 athn-10">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" title="4.4.10 Testing for Weaker Authentication in Alternative Channel">4.4.10 Testing for Weaker Authentication in Alternative Channel</a>
 </li>
 </ul>
@@ -263,16 +263,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include">
+<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include" data-hints="path traversal dotdot lfi wstg-athz-01 athz-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" title="4.5.1 Testing Directory Traversal File Include">4.5.1 Testing Directory Traversal File Include</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema">
+<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema" data-hints="wstg-athz-02 athz-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" title="4.5.2 Testing for Bypassing Authorization Schema">4.5.2 Testing for Bypassing Authorization Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation">
+<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation" data-hints="privesc wstg-athz-03 athz-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" title="4.5.3 Testing for Privilege Escalation">4.5.3 Testing for Privilege Escalation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References">
+<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References" data-hints="idor wstg-athz-04 athz-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" title="4.5.4 Testing for Insecure Direct Object References">4.5.4 Testing for Insecure Direct Object References</a>
 </li>
 </ul>
@@ -287,28 +287,28 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema">
+<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema" data-hints="wstg-sess-01 sess-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" title="4.6.1 Testing for Session Management Schema">4.6.1 Testing for Session Management Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes">
+<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes" data-hints="cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" title="4.6.2 Testing for Cookies Attributes">4.6.2 Testing for Cookies Attributes</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation">
+<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation" data-hints="wstg-sess-03 sess-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" title="4.6.3 Testing for Session Fixation">4.6.3 Testing for Session Fixation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables">
+<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables" data-hints="wstg-sess-04 sess-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" title="4.6.4 Testing for Exposed Session Variables">4.6.4 Testing for Exposed Session Variables</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery">
+<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery" data-hints="csrf xsrf wstg-sess-05 sess-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" title="4.6.5 Testing for Cross Site Request Forgery">4.6.5 Testing for Cross Site Request Forgery</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality">
+<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality" data-hints="wstg-sess-06 sess-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" title="4.6.6 Testing for Logout Functionality">4.6.6 Testing for Logout Functionality</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout">
+<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout" data-hints="wstg-sess-07 sess-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" title="4.6.7 Testing Session Timeout">4.6.7 Testing Session Timeout</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling">
+<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling" data-hints="wstg-sess-08 sess-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" title="4.6.8 Testing for Session Puzzling">4.6.8 Testing for Session Puzzling</a>
 </li>
 </ul>
@@ -323,19 +323,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting" data-hints="xss wstg-inpv-01 inpv-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" title="4.7.1 Testing for Reflected Cross Site Scripting">4.7.1 Testing for Reflected Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting" data-hints="xss wstg-inpv-02 inpv-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" title="4.7.2 Testing for Stored Cross Site Scripting">4.7.2 Testing for Stored Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering">
+<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering" data-hints="verb tampering wstg-inpv-03 inpv-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" title="4.7.3 Testing for HTTP Verb Tampering">4.7.3 Testing for HTTP Verb Tampering</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution">
+<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution" data-hints="hpp wstg-inpv-04 inpv-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" title="4.7.4 Testing for HTTP Parameter Pollution">4.7.4 Testing for HTTP Parameter Pollution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection" data-hints="sqli wstg-inpv-05 inpv-05">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -350,7 +350,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.2 Testing for MySQL">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" title="4.7.5.2 Testing for MySQL">4.7.5.2 Testing for MySQL</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server">
+<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server" data-hints="mssql sql server">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" title="4.7.5.3 Testing for SQL Server">4.7.5.3 Testing for SQL Server</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.4 Testing PostgreSQL">
@@ -359,7 +359,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.5 Testing for MS Access">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" title="4.7.5.5 Testing for MS Access">4.7.5.5 Testing for MS Access</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection" data-hints="sqli nosqli">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" title="4.7.5.6 Testing for NoSQL Injection">4.7.5.6 Testing for NoSQL Injection</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.7 Testing for ORM Injection">
@@ -371,22 +371,22 @@
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection">
+<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection" data-hints="ldapi wstg-inpv-06 inpv-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" title="4.7.6 Testing for LDAP Injection">4.7.6 Testing for LDAP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection">
+<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection" data-hints="xxe xmli xml injection wstg-inpv-07 inpv-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" title="4.7.7 Testing for XML Injection">4.7.7 Testing for XML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection">
+<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection" data-hints="ssi injection wstg-inpv-08 inpv-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" title="4.7.8 Testing for SSI Injection">4.7.8 Testing for SSI Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection">
+<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection" data-hints="xpathi xml wstg-inpv-09 inpv-09">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" title="4.7.9 Testing for XPath Injection">4.7.9 Testing for XPath Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection">
+<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection" data-hints="email injection wstg-inpv-10 inpv-10">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" title="4.7.10 Testing for IMAP SMTP Injection">4.7.10 Testing for IMAP SMTP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection">
+<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection" data-hints="rce wstg-inpv-11 inpv-11">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -395,19 +395,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.11.1 Testing for Local File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.1 Testing for Local File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion" title="4.7.11.1 Testing for Local File Inclusion">4.7.11.1 Testing for Local File Inclusion</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11.2 Testing for Remote File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.2 Testing for Remote File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion" title="4.7.11.2 Testing for Remote File Inclusion">4.7.11.2 Testing for Remote File Inclusion</a>
 </li>
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection">
+<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection" data-hints="rce cmdi os command wstg-inpv-12 inpv-12">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" title="4.7.12 Testing for Command Injection">4.7.12 Testing for Command Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.13 Testing for Buffer Overflow">
+<li class="wstg-nav-item" data-title="4.7.13 Testing for Buffer Overflow" data-hints="wstg-inpv-13 inpv-13">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -422,25 +422,25 @@
 <li class="wstg-nav-item" data-title="4.7.13.2 Testing for Stack Overflow">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.2-Testing_for_Stack_Overflow" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.2-Testing_for_Stack_Overflow" title="4.7.13.2 Testing for Stack Overflow">4.7.13.2 Testing for Stack Overflow</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.13.3 Testing for Format String">
+<li class="wstg-nav-item" data-title="4.7.13.3 Testing for Format String" data-hints="format string bug">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.3-Testing_for_Format_String" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/13.3-Testing_for_Format_String" title="4.7.13.3 Testing for Format String">4.7.13.3 Testing for Format String</a>
 </li>
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability">
+<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability" data-hints="wstg-inpv-14 inpv-14">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" title="4.7.14 Testing for Incubated Vulnerability">4.7.14 Testing for Incubated Vulnerability</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Splitting Smuggling">
+<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Splitting Smuggling" data-hints="wstg-inpv-15 inpv-15">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling" title="4.7.15 Testing for HTTP Splitting Smuggling">4.7.15 Testing for HTTP Splitting Smuggling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Incoming Requests">
+<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Incoming Requests" data-hints="wstg-inpv-16 inpv-16">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests" title="4.7.16 Testing for HTTP Incoming Requests">4.7.16 Testing for HTTP Incoming Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection">
+<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection" data-hints="host header injection headers wstg-inpv-17 inpv-17">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" title="4.7.17 Testing for Host Header Injection">4.7.17 Testing for Host Header Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.18 Testing for Server Side Template Injection">
+<li class="wstg-nav-item" data-title="4.7.18 Testing for Server Side Template Injection" data-hints="ssti wstg-inpv-18 inpv-18">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection" title="4.7.18 Testing for Server Side Template Injection">4.7.18 Testing for Server Side Template Injection</a>
 </li>
 </ul>
@@ -455,10 +455,10 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.8.1 Testing for Error Code">
+<li class="wstg-nav-item" data-title="4.8.1 Testing for Error Code" data-hints="wstg-errh-01 errh-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_for_Error_Code" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_for_Error_Code" title="4.8.1 Testing for Error Code">4.8.1 Testing for Error Code</a>
 </li>
-<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces">
+<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces" data-hints="wstg-errh-02 errh-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" title="4.8.2 Testing for Stack Traces">4.8.2 Testing for Stack Traces</a>
 </li>
 </ul>
@@ -473,16 +473,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak SSL TLS Ciphers Insufficient Transport Layer Protection">
+<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak SSL TLS Ciphers Insufficient Transport Layer Protection" data-hints="wstg-cryp-01 cryp-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection" title="4.9.1 Testing for Weak SSL TLS Ciphers Insufficient Transport Layer Protection">4.9.1 Testing for Weak SSL TLS Ciphers Insufficient Transport Layer Protection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle">
+<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle" data-hints="padding oracle attack wstg-cryp-02 cryp-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" title="4.9.2 Testing for Padding Oracle">4.9.2 Testing for Padding Oracle</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">
+<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels" data-hints="tls ssl https cleartext wstg-cryp-03 cryp-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Encryption">
+<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Encryption" data-hints="wstg-cryp-04 cryp-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption" title="4.9.4 Testing for Weak Encryption">4.9.4 Testing for Weak Encryption</a>
 </li>
 </ul>
@@ -500,31 +500,31 @@
 <li class="wstg-nav-item" data-title="4.10.0 Introduction to Business Logic">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" title="4.10.0 Introduction to Business Logic">4.10.0 Introduction to Business Logic</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation">
+<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation" data-hints="wstg-busl-01 busl-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" title="4.10.1 Test Business Logic Data Validation">4.10.1 Test Business Logic Data Validation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests">
+<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests" data-hints="wstg-busl-02 busl-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" title="4.10.2 Test Ability to Forge Requests">4.10.2 Test Ability to Forge Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks">
+<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks" data-hints="wstg-busl-03 busl-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" title="4.10.3 Test Integrity Checks">4.10.3 Test Integrity Checks</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing">
+<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing" data-hints="race condition toctou wstg-busl-04 busl-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" title="4.10.4 Test for Process Timing">4.10.4 Test for Process Timing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits">
+<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits" data-hints="rate limit bruteforce brute force wstg-busl-05 busl-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" title="4.10.5 Test Number of Times a Function Can Be Used Limits">4.10.5 Test Number of Times a Function Can Be Used Limits</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows">
+<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows" data-hints="wstg-busl-06 busl-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" title="4.10.6 Testing for the Circumvention of Work Flows">4.10.6 Testing for the Circumvention of Work Flows</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse">
+<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse" data-hints="wstg-busl-07 busl-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" title="4.10.7 Test Defenses Against Application Misuse">4.10.7 Test Defenses Against Application Misuse</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types">
+<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types" data-hints="wstg-busl-08 busl-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" title="4.10.8 Test Upload of Unexpected File Types">4.10.8 Test Upload of Unexpected File Types</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files">
+<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files" data-hints="wstg-busl-09 busl-09">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" title="4.10.9 Test Upload of Malicious Files">4.10.9 Test Upload of Malicious Files</a>
 </li>
 </ul>
@@ -539,43 +539,43 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting" data-hints="xss dom xss domxss wstg-clnt-01 clnt-01">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting" title="4.11.1 Testing for DOM-Based Cross Site Scripting">4.11.1 Testing for DOM-Based Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution">
+<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution" data-hints="wstg-clnt-02 clnt-02">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/02-Testing_for_JavaScript_Execution" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/02-Testing_for_JavaScript_Execution" title="4.11.2 Testing for JavaScript Execution">4.11.2 Testing for JavaScript Execution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection">
+<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection" data-hints="wstg-clnt-03 clnt-03">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/03-Testing_for_HTML_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/03-Testing_for_HTML_Injection" title="4.11.3 Testing for HTML Injection">4.11.3 Testing for HTML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.4 Testing for Client Side URL Redirect">
+<li class="wstg-nav-item" data-title="4.11.4 Testing for Client Side URL Redirect" data-hints="open redirect wstg-clnt-04 clnt-04">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/04-Testing_for_Client_Side_URL_Redirect" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/04-Testing_for_Client_Side_URL_Redirect" title="4.11.4 Testing for Client Side URL Redirect">4.11.4 Testing for Client Side URL Redirect</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection">
+<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection" data-hints="wstg-clnt-05 clnt-05">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection" title="4.11.5 Testing for CSS Injection">4.11.5 Testing for CSS Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.6 Testing for Client Side Resource Manipulation">
+<li class="wstg-nav-item" data-title="4.11.6 Testing for Client Side Resource Manipulation" data-hints="wstg-clnt-06 clnt-06">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/06-Testing_for_Client_Side_Resource_Manipulation" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/06-Testing_for_Client_Side_Resource_Manipulation" title="4.11.6 Testing for Client Side Resource Manipulation">4.11.6 Testing for Client Side Resource Manipulation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing">
+<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing" data-hints="cors headers wstg-clnt-07 clnt-07">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/07-Testing_Cross_Origin_Resource_Sharing" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/07-Testing_Cross_Origin_Resource_Sharing" title="4.11.7 Testing Cross Origin Resource Sharing">4.11.7 Testing Cross Origin Resource Sharing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing">
+<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing" data-hints="wstg-clnt-08 clnt-08">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/08-Testing_for_Cross_Site_Flashing" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/08-Testing_for_Cross_Site_Flashing" title="4.11.8 Testing for Cross Site Flashing">4.11.8 Testing for Cross Site Flashing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking">
+<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking" data-hints="ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/09-Testing_for_Clickjacking" title="4.11.9 Testing for Clickjacking">4.11.9 Testing for Clickjacking</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets">
+<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets" data-hints="ws wstg-clnt-10 clnt-10">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/10-Testing_WebSockets" title="4.11.10 Testing WebSockets">4.11.10 Testing WebSockets</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging">
+<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging" data-hints="postmessage post message wstg-clnt-11 clnt-11">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/11-Testing_Web_Messaging" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/11-Testing_Web_Messaging" title="4.11.11 Testing Web Messaging">4.11.11 Testing Web Messaging</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage">
+<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage" data-hints="localstorage sessionstorage wstg-clnt-12 clnt-12">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/12-Testing_Browser_Storage" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/12-Testing_Browser_Storage" title="4.11.12 Testing Browser Storage">4.11.12 Testing Browser Storage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion">
+<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion" data-hints="xssi wstg-clnt-13 clnt-13">
 <a href="{{ site.baseurl }}/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" data-nav-url="4-Web_Application_Security_Testing/11-Client_Side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" title="4.11.13 Testing for Cross Site Script Inclusion">4.11.13 Testing for Cross Site Script Inclusion</a>
 </li>
 </ul>

--- a/_includes/nav-tree-v42.html
+++ b/_includes/nav-tree-v42.html
@@ -107,34 +107,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage" data-hints="wstg-info-01 info-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage" title="4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage">4.1.1 Conduct Search Engine Discovery Reconnaissance for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server">
+<li class="wstg-nav-item" data-title="4.1.2 Fingerprint Web Server" data-hints="wstg-info-02 info-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/02-Fingerprint_Web_Server" title="4.1.2 Fingerprint Web Server">4.1.2 Fingerprint Web Server</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.3 Review Webserver Metafiles for Information Leakage" data-hints="robots robots.txt sitemap sitemap.xml wstg-info-03 info-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage" title="4.1.3 Review Webserver Metafiles for Information Leakage">4.1.3 Review Webserver Metafiles for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.4 Enumerate Applications on Webserver">
+<li class="wstg-nav-item" data-title="4.1.4 Enumerate Applications on Webserver" data-hints="wstg-info-04 info-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/04-Enumerate_Applications_on_Webserver" title="4.1.4 Enumerate Applications on Webserver">4.1.4 Enumerate Applications on Webserver</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.5 Review Webpage Content for Information Leakage">
+<li class="wstg-nav-item" data-title="4.1.5 Review Webpage Content for Information Leakage" data-hints="wstg-info-05 info-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/05-Review_Webpage_Content_for_Information_Leakage" title="4.1.5 Review Webpage Content for Information Leakage">4.1.5 Review Webpage Content for Information Leakage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points">
+<li class="wstg-nav-item" data-title="4.1.6 Identify Application Entry Points" data-hints="wstg-info-06 info-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/06-Identify_Application_Entry_Points" title="4.1.6 Identify Application Entry Points">4.1.6 Identify Application Entry Points</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application">
+<li class="wstg-nav-item" data-title="4.1.7 Map Execution Paths Through Application" data-hints="wstg-info-07 info-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/07-Map_Execution_Paths_Through_Application" title="4.1.7 Map Execution Paths Through Application">4.1.7 Map Execution Paths Through Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework">
+<li class="wstg-nav-item" data-title="4.1.8 Fingerprint Web Application Framework" data-hints="wstg-info-08 info-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework" title="4.1.8 Fingerprint Web Application Framework">4.1.8 Fingerprint Web Application Framework</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application">
+<li class="wstg-nav-item" data-title="4.1.9 Fingerprint Web Application" data-hints="wstg-info-09 info-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/09-Fingerprint_Web_Application" title="4.1.9 Fingerprint Web Application">4.1.9 Fingerprint Web Application</a>
 </li>
-<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture">
+<li class="wstg-nav-item" data-title="4.1.10 Map Application Architecture" data-hints="wstg-info-10 info-10">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" data-nav-url="4-Web_Application_Security_Testing/01-Information_Gathering/10-Map_Application_Architecture" title="4.1.10 Map Application Architecture">4.1.10 Map Application Architecture</a>
 </li>
 </ul>
@@ -149,37 +149,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration">
+<li class="wstg-nav-item" data-title="4.2.1 Test Network Infrastructure Configuration" data-hints="wstg-conf-01 conf-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/01-Test_Network_Infrastructure_Configuration" title="4.2.1 Test Network Infrastructure Configuration">4.2.1 Test Network Infrastructure Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration">
+<li class="wstg-nav-item" data-title="4.2.2 Test Application Platform Configuration" data-hints="wstg-conf-02 conf-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/02-Test_Application_Platform_Configuration" title="4.2.2 Test Application Platform Configuration">4.2.2 Test Application Platform Configuration</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.3 Test File Extensions Handling for Sensitive Information" data-hints="wstg-conf-03 conf-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/03-Test_File_Extensions_Handling_for_Sensitive_Information" title="4.2.3 Test File Extensions Handling for Sensitive Information">4.2.3 Test File Extensions Handling for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">
+<li class="wstg-nav-item" data-title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information" data-hints="wstg-conf-04 conf-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information" title="4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information">4.2.4 Review Old Backup and Unreferenced Files for Sensitive Information</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">
+<li class="wstg-nav-item" data-title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces" data-hints="wstg-conf-05 conf-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/05-Enumerate_Infrastructure_and_Application_Admin_Interfaces" title="4.2.5 Enumerate Infrastructure and Application Admin Interfaces">4.2.5 Enumerate Infrastructure and Application Admin Interfaces</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods">
+<li class="wstg-nav-item" data-title="4.2.6 Test HTTP Methods" data-hints="wstg-conf-06 conf-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods" title="4.2.6 Test HTTP Methods">4.2.6 Test HTTP Methods</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security">
+<li class="wstg-nav-item" data-title="4.2.7 Test HTTP Strict Transport Security" data-hints="hsts headers wstg-conf-07 conf-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security" title="4.2.7 Test HTTP Strict Transport Security">4.2.7 Test HTTP Strict Transport Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy">
+<li class="wstg-nav-item" data-title="4.2.8 Test RIA Cross Domain Policy" data-hints="crossdomain.xml clientaccesspolicy wstg-conf-08 conf-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/08-Test_RIA_Cross_Domain_Policy" title="4.2.8 Test RIA Cross Domain Policy">4.2.8 Test RIA Cross Domain Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.9 Test File Permission">
+<li class="wstg-nav-item" data-title="4.2.9 Test File Permission" data-hints="wstg-conf-09 conf-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/09-Test_File_Permission" title="4.2.9 Test File Permission">4.2.9 Test File Permission</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover">
+<li class="wstg-nav-item" data-title="4.2.10 Test for Subdomain Takeover" data-hints="wstg-conf-10 conf-10">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover" title="4.2.10 Test for Subdomain Takeover">4.2.10 Test for Subdomain Takeover</a>
 </li>
-<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage">
+<li class="wstg-nav-item" data-title="4.2.11 Test Cloud Storage" data-hints="s3 bucket blob storage wstg-conf-11 conf-11">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" data-nav-url="4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/11-Test_Cloud_Storage" title="4.2.11 Test Cloud Storage">4.2.11 Test Cloud Storage</a>
 </li>
 </ul>
@@ -194,19 +194,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions">
+<li class="wstg-nav-item" data-title="4.3.1 Test Role Definitions" data-hints="wstg-idnt-01 idnt-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/01-Test_Role_Definitions" title="4.3.1 Test Role Definitions">4.3.1 Test Role Definitions</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process">
+<li class="wstg-nav-item" data-title="4.3.2 Test User Registration Process" data-hints="wstg-idnt-02 idnt-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/02-Test_User_Registration_Process" title="4.3.2 Test User Registration Process">4.3.2 Test User Registration Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process">
+<li class="wstg-nav-item" data-title="4.3.3 Test Account Provisioning Process" data-hints="wstg-idnt-03 idnt-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/03-Test_Account_Provisioning_Process" title="4.3.3 Test Account Provisioning Process">4.3.3 Test Account Provisioning Process</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account">
+<li class="wstg-nav-item" data-title="4.3.4 Testing for Account Enumeration and Guessable User Account" data-hints="wstg-idnt-04 idnt-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account" title="4.3.4 Testing for Account Enumeration and Guessable User Account">4.3.4 Testing for Account Enumeration and Guessable User Account</a>
 </li>
-<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy">
+<li class="wstg-nav-item" data-title="4.3.5 Testing for Weak or Unenforced Username Policy" data-hints="wstg-idnt-05 idnt-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" data-nav-url="4-Web_Application_Security_Testing/03-Identity_Management_Testing/05-Testing_for_Weak_or_Unenforced_Username_Policy" title="4.3.5 Testing for Weak or Unenforced Username Policy">4.3.5 Testing for Weak or Unenforced Username Policy</a>
 </li>
 </ul>
@@ -221,34 +221,34 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">
+<li class="wstg-nav-item" data-title="4.4.1 Testing for Credentials Transported over an Encrypted Channel" data-hints="tls ssl https wstg-athn-01 athn-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/01-Testing_for_Credentials_Transported_over_an_Encrypted_Channel" title="4.4.1 Testing for Credentials Transported over an Encrypted Channel">4.4.1 Testing for Credentials Transported over an Encrypted Channel</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials">
+<li class="wstg-nav-item" data-title="4.4.2 Testing for Default Credentials" data-hints="wstg-athn-02 athn-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials" title="4.4.2 Testing for Default Credentials">4.4.2 Testing for Default Credentials</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism">
+<li class="wstg-nav-item" data-title="4.4.3 Testing for Weak Lock Out Mechanism" data-hints="rate limit bruteforce brute force account lockout wstg-athn-03 athn-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism" title="4.4.3 Testing for Weak Lock Out Mechanism">4.4.3 Testing for Weak Lock Out Mechanism</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema">
+<li class="wstg-nav-item" data-title="4.4.4 Testing for Bypassing Authentication Schema" data-hints="wstg-athn-04 athn-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/04-Testing_for_Bypassing_Authentication_Schema" title="4.4.4 Testing for Bypassing Authentication Schema">4.4.4 Testing for Bypassing Authentication Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password">
+<li class="wstg-nav-item" data-title="4.4.5 Testing for Vulnerable Remember Password" data-hints="wstg-athn-05 athn-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/05-Testing_for_Vulnerable_Remember_Password" title="4.4.5 Testing for Vulnerable Remember Password">4.4.5 Testing for Vulnerable Remember Password</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses">
+<li class="wstg-nav-item" data-title="4.4.6 Testing for Browser Cache Weaknesses" data-hints="wstg-athn-06 athn-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses" title="4.4.6 Testing for Browser Cache Weaknesses">4.4.6 Testing for Browser Cache Weaknesses</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Password Policy">
+<li class="wstg-nav-item" data-title="4.4.7 Testing for Weak Password Policy" data-hints="wstg-athn-07 athn-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy" title="4.4.7 Testing for Weak Password Policy">4.4.7 Testing for Weak Password Policy</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer">
+<li class="wstg-nav-item" data-title="4.4.8 Testing for Weak Security Question Answer" data-hints="wstg-athn-08 athn-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/08-Testing_for_Weak_Security_Question_Answer" title="4.4.8 Testing for Weak Security Question Answer">4.4.8 Testing for Weak Security Question Answer</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities">
+<li class="wstg-nav-item" data-title="4.4.9 Testing for Weak Password Change or Reset Functionalities" data-hints="wstg-athn-09 athn-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/09-Testing_for_Weak_Password_Change_or_Reset_Functionalities" title="4.4.9 Testing for Weak Password Change or Reset Functionalities">4.4.9 Testing for Weak Password Change or Reset Functionalities</a>
 </li>
-<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel">
+<li class="wstg-nav-item" data-title="4.4.10 Testing for Weaker Authentication in Alternative Channel" data-hints="wstg-athn-10 athn-10">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" data-nav-url="4-Web_Application_Security_Testing/04-Authentication_Testing/10-Testing_for_Weaker_Authentication_in_Alternative_Channel" title="4.4.10 Testing for Weaker Authentication in Alternative Channel">4.4.10 Testing for Weaker Authentication in Alternative Channel</a>
 </li>
 </ul>
@@ -263,16 +263,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include">
+<li class="wstg-nav-item" data-title="4.5.1 Testing Directory Traversal File Include" data-hints="path traversal dotdot lfi wstg-athz-01 athz-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/01-Testing_Directory_Traversal_File_Include" title="4.5.1 Testing Directory Traversal File Include">4.5.1 Testing Directory Traversal File Include</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema">
+<li class="wstg-nav-item" data-title="4.5.2 Testing for Bypassing Authorization Schema" data-hints="wstg-athz-02 athz-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/02-Testing_for_Bypassing_Authorization_Schema" title="4.5.2 Testing for Bypassing Authorization Schema">4.5.2 Testing for Bypassing Authorization Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation">
+<li class="wstg-nav-item" data-title="4.5.3 Testing for Privilege Escalation" data-hints="privesc wstg-athz-03 athz-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/03-Testing_for_Privilege_Escalation" title="4.5.3 Testing for Privilege Escalation">4.5.3 Testing for Privilege Escalation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References">
+<li class="wstg-nav-item" data-title="4.5.4 Testing for Insecure Direct Object References" data-hints="idor wstg-athz-04 athz-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" data-nav-url="4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References" title="4.5.4 Testing for Insecure Direct Object References">4.5.4 Testing for Insecure Direct Object References</a>
 </li>
 </ul>
@@ -287,31 +287,31 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema">
+<li class="wstg-nav-item" data-title="4.6.1 Testing for Session Management Schema" data-hints="wstg-sess-01 sess-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/01-Testing_for_Session_Management_Schema" title="4.6.1 Testing for Session Management Schema">4.6.1 Testing for Session Management Schema</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes">
+<li class="wstg-nav-item" data-title="4.6.2 Testing for Cookies Attributes" data-hints="cookies set-cookie httponly samesite secure flag wstg-sess-02 sess-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes" title="4.6.2 Testing for Cookies Attributes">4.6.2 Testing for Cookies Attributes</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation">
+<li class="wstg-nav-item" data-title="4.6.3 Testing for Session Fixation" data-hints="wstg-sess-03 sess-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/03-Testing_for_Session_Fixation" title="4.6.3 Testing for Session Fixation">4.6.3 Testing for Session Fixation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables">
+<li class="wstg-nav-item" data-title="4.6.4 Testing for Exposed Session Variables" data-hints="wstg-sess-04 sess-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/04-Testing_for_Exposed_Session_Variables" title="4.6.4 Testing for Exposed Session Variables">4.6.4 Testing for Exposed Session Variables</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery">
+<li class="wstg-nav-item" data-title="4.6.5 Testing for Cross Site Request Forgery" data-hints="csrf xsrf wstg-sess-05 sess-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/05-Testing_for_Cross_Site_Request_Forgery" title="4.6.5 Testing for Cross Site Request Forgery">4.6.5 Testing for Cross Site Request Forgery</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality">
+<li class="wstg-nav-item" data-title="4.6.6 Testing for Logout Functionality" data-hints="wstg-sess-06 sess-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/06-Testing_for_Logout_Functionality" title="4.6.6 Testing for Logout Functionality">4.6.6 Testing for Logout Functionality</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout">
+<li class="wstg-nav-item" data-title="4.6.7 Testing Session Timeout" data-hints="wstg-sess-07 sess-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/07-Testing_Session_Timeout" title="4.6.7 Testing Session Timeout">4.6.7 Testing Session Timeout</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling">
+<li class="wstg-nav-item" data-title="4.6.8 Testing for Session Puzzling" data-hints="wstg-sess-08 sess-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/08-Testing_for_Session_Puzzling" title="4.6.8 Testing for Session Puzzling">4.6.8 Testing for Session Puzzling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.6.9 Testing for Session Hijacking">
+<li class="wstg-nav-item" data-title="4.6.9 Testing for Session Hijacking" data-hints="wstg-sess-09 sess-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking" data-nav-url="4-Web_Application_Security_Testing/06-Session_Management_Testing/09-Testing_for_Session_Hijacking" title="4.6.9 Testing for Session Hijacking">4.6.9 Testing for Session Hijacking</a>
 </li>
 </ul>
@@ -326,19 +326,19 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.1 Testing for Reflected Cross Site Scripting" data-hints="xss wstg-inpv-01 inpv-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/01-Testing_for_Reflected_Cross_Site_Scripting" title="4.7.1 Testing for Reflected Cross Site Scripting">4.7.1 Testing for Reflected Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.7.2 Testing for Stored Cross Site Scripting" data-hints="xss wstg-inpv-02 inpv-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/02-Testing_for_Stored_Cross_Site_Scripting" title="4.7.2 Testing for Stored Cross Site Scripting">4.7.2 Testing for Stored Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering">
+<li class="wstg-nav-item" data-title="4.7.3 Testing for HTTP Verb Tampering" data-hints="verb tampering wstg-inpv-03 inpv-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/03-Testing_for_HTTP_Verb_Tampering" title="4.7.3 Testing for HTTP Verb Tampering">4.7.3 Testing for HTTP Verb Tampering</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution">
+<li class="wstg-nav-item" data-title="4.7.4 Testing for HTTP Parameter Pollution" data-hints="hpp wstg-inpv-04 inpv-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution" title="4.7.4 Testing for HTTP Parameter Pollution">4.7.4 Testing for HTTP Parameter Pollution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5 Testing for SQL Injection" data-hints="sqli wstg-inpv-05 inpv-05">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -353,7 +353,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.2 Testing for MySQL">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.2-Testing_for_MySQL" title="4.7.5.2 Testing for MySQL">4.7.5.2 Testing for MySQL</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server">
+<li class="wstg-nav-item" data-title="4.7.5.3 Testing for SQL Server" data-hints="mssql sql server">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.3-Testing_for_SQL_Server" title="4.7.5.3 Testing for SQL Server">4.7.5.3 Testing for SQL Server</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.4 Testing PostgreSQL">
@@ -362,7 +362,7 @@
 <li class="wstg-nav-item" data-title="4.7.5.5 Testing for MS Access">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.5-Testing_for_MS_Access" title="4.7.5.5 Testing for MS Access">4.7.5.5 Testing for MS Access</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection">
+<li class="wstg-nav-item" data-title="4.7.5.6 Testing for NoSQL Injection" data-hints="sqli nosqli">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection" title="4.7.5.6 Testing for NoSQL Injection">4.7.5.6 Testing for NoSQL Injection</a>
 </li>
 <li class="wstg-nav-item" data-title="4.7.5.7 Testing for ORM Injection">
@@ -374,22 +374,22 @@
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection">
+<li class="wstg-nav-item" data-title="4.7.6 Testing for LDAP Injection" data-hints="ldapi wstg-inpv-06 inpv-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection" title="4.7.6 Testing for LDAP Injection">4.7.6 Testing for LDAP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection">
+<li class="wstg-nav-item" data-title="4.7.7 Testing for XML Injection" data-hints="xxe xmli xml injection wstg-inpv-07 inpv-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection" title="4.7.7 Testing for XML Injection">4.7.7 Testing for XML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection">
+<li class="wstg-nav-item" data-title="4.7.8 Testing for SSI Injection" data-hints="ssi injection wstg-inpv-08 inpv-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/08-Testing_for_SSI_Injection" title="4.7.8 Testing for SSI Injection">4.7.8 Testing for SSI Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection">
+<li class="wstg-nav-item" data-title="4.7.9 Testing for XPath Injection" data-hints="xpathi xml wstg-inpv-09 inpv-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection" title="4.7.9 Testing for XPath Injection">4.7.9 Testing for XPath Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection">
+<li class="wstg-nav-item" data-title="4.7.10 Testing for IMAP SMTP Injection" data-hints="email injection wstg-inpv-10 inpv-10">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/10-Testing_for_IMAP_SMTP_Injection" title="4.7.10 Testing for IMAP SMTP Injection">4.7.10 Testing for IMAP SMTP Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection">
+<li class="wstg-nav-item" data-title="4.7.11 Testing for Code Injection" data-hints="rce wstg-inpv-11 inpv-11">
 <details>
 <summary>
 <span class="wstg-nav-summary-row">
@@ -398,37 +398,37 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.7.11.1 Testing for Local File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.1 Testing for Local File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion" title="4.7.11.1 Testing for Local File Inclusion">4.7.11.1 Testing for Local File Inclusion</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.11.2 Testing for Remote File Inclusion">
+<li class="wstg-nav-item" data-title="4.7.11.2 Testing for Remote File Inclusion" data-hints="lfi rfi">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.2-Testing_for_Remote_File_Inclusion" title="4.7.11.2 Testing for Remote File Inclusion">4.7.11.2 Testing for Remote File Inclusion</a>
 </li>
 </ul>
 </details>
 </li>
-<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection">
+<li class="wstg-nav-item" data-title="4.7.12 Testing for Command Injection" data-hints="rce cmdi os command wstg-inpv-12 inpv-12">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/12-Testing_for_Command_Injection" title="4.7.12 Testing for Command Injection">4.7.12 Testing for Command Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.13 Testing for Format String Injection">
+<li class="wstg-nav-item" data-title="4.7.13 Testing for Format String Injection" data-hints="format string bug wstg-inpv-13 inpv-13">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/13-Testing_for_Format_String_Injection" title="4.7.13 Testing for Format String Injection">4.7.13 Testing for Format String Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability">
+<li class="wstg-nav-item" data-title="4.7.14 Testing for Incubated Vulnerability" data-hints="wstg-inpv-14 inpv-14">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/14-Testing_for_Incubated_Vulnerability" title="4.7.14 Testing for Incubated Vulnerability">4.7.14 Testing for Incubated Vulnerability</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Splitting Smuggling">
+<li class="wstg-nav-item" data-title="4.7.15 Testing for HTTP Splitting Smuggling" data-hints="wstg-inpv-15 inpv-15">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Splitting_Smuggling" title="4.7.15 Testing for HTTP Splitting Smuggling">4.7.15 Testing for HTTP Splitting Smuggling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Incoming Requests">
+<li class="wstg-nav-item" data-title="4.7.16 Testing for HTTP Incoming Requests" data-hints="wstg-inpv-16 inpv-16">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/16-Testing_for_HTTP_Incoming_Requests" title="4.7.16 Testing for HTTP Incoming Requests">4.7.16 Testing for HTTP Incoming Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection">
+<li class="wstg-nav-item" data-title="4.7.17 Testing for Host Header Injection" data-hints="host header injection headers wstg-inpv-17 inpv-17">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection" title="4.7.17 Testing for Host Header Injection">4.7.17 Testing for Host Header Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.18 Testing for Server-side Template Injection">
+<li class="wstg-nav-item" data-title="4.7.18 Testing for Server-side Template Injection" data-hints="ssti wstg-inpv-18 inpv-18">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server-side_Template_Injection" title="4.7.18 Testing for Server-side Template Injection">4.7.18 Testing for Server-side Template Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.7.19 Testing for Server-Side Request Forgery">
+<li class="wstg-nav-item" data-title="4.7.19 Testing for Server-Side Request Forgery" data-hints="ssrf wstg-inpv-19 inpv-19">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery" data-nav-url="4-Web_Application_Security_Testing/07-Input_Validation_Testing/19-Testing_for_Server-Side_Request_Forgery" title="4.7.19 Testing for Server-Side Request Forgery">4.7.19 Testing for Server-Side Request Forgery</a>
 </li>
 </ul>
@@ -443,10 +443,10 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.8.1 Testing for Improper Error Handling">
+<li class="wstg-nav-item" data-title="4.8.1 Testing for Improper Error Handling" data-hints="wstg-errh-01 errh-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling" title="4.8.1 Testing for Improper Error Handling">4.8.1 Testing for Improper Error Handling</a>
 </li>
-<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces">
+<li class="wstg-nav-item" data-title="4.8.2 Testing for Stack Traces" data-hints="wstg-errh-02 errh-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" data-nav-url="4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/02-Testing_for_Stack_Traces" title="4.8.2 Testing for Stack Traces">4.8.2 Testing for Stack Traces</a>
 </li>
 </ul>
@@ -461,16 +461,16 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak Transport Layer Security">
+<li class="wstg-nav-item" data-title="4.9.1 Testing for Weak Transport Layer Security" data-hints="tls ssl https wstg-cryp-01 cryp-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_Transport_Layer_Security" title="4.9.1 Testing for Weak Transport Layer Security">4.9.1 Testing for Weak Transport Layer Security</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle">
+<li class="wstg-nav-item" data-title="4.9.2 Testing for Padding Oracle" data-hints="padding oracle attack wstg-cryp-02 cryp-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle" title="4.9.2 Testing for Padding Oracle">4.9.2 Testing for Padding Oracle</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">
+<li class="wstg-nav-item" data-title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels" data-hints="tls ssl https cleartext wstg-cryp-03 cryp-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/03-Testing_for_Sensitive_Information_Sent_via_Unencrypted_Channels" title="4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels">4.9.3 Testing for Sensitive Information Sent via Unencrypted Channels</a>
 </li>
-<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Encryption">
+<li class="wstg-nav-item" data-title="4.9.4 Testing for Weak Encryption" data-hints="wstg-cryp-04 cryp-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption" data-nav-url="4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption" title="4.9.4 Testing for Weak Encryption">4.9.4 Testing for Weak Encryption</a>
 </li>
 </ul>
@@ -488,31 +488,31 @@
 <li class="wstg-nav-item" data-title="4.10.0 Introduction to Business Logic">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/00-Introduction_to_Business_Logic" title="4.10.0 Introduction to Business Logic">4.10.0 Introduction to Business Logic</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation">
+<li class="wstg-nav-item" data-title="4.10.1 Test Business Logic Data Validation" data-hints="wstg-busl-01 busl-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/01-Test_Business_Logic_Data_Validation" title="4.10.1 Test Business Logic Data Validation">4.10.1 Test Business Logic Data Validation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests">
+<li class="wstg-nav-item" data-title="4.10.2 Test Ability to Forge Requests" data-hints="wstg-busl-02 busl-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/02-Test_Ability_to_Forge_Requests" title="4.10.2 Test Ability to Forge Requests">4.10.2 Test Ability to Forge Requests</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks">
+<li class="wstg-nav-item" data-title="4.10.3 Test Integrity Checks" data-hints="wstg-busl-03 busl-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/03-Test_Integrity_Checks" title="4.10.3 Test Integrity Checks">4.10.3 Test Integrity Checks</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing">
+<li class="wstg-nav-item" data-title="4.10.4 Test for Process Timing" data-hints="race condition toctou wstg-busl-04 busl-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/04-Test_for_Process_Timing" title="4.10.4 Test for Process Timing">4.10.4 Test for Process Timing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits">
+<li class="wstg-nav-item" data-title="4.10.5 Test Number of Times a Function Can Be Used Limits" data-hints="rate limit bruteforce brute force wstg-busl-05 busl-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/05-Test_Number_of_Times_a_Function_Can_Be_Used_Limits" title="4.10.5 Test Number of Times a Function Can Be Used Limits">4.10.5 Test Number of Times a Function Can Be Used Limits</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows">
+<li class="wstg-nav-item" data-title="4.10.6 Testing for the Circumvention of Work Flows" data-hints="wstg-busl-06 busl-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/06-Testing_for_the_Circumvention_of_Work_Flows" title="4.10.6 Testing for the Circumvention of Work Flows">4.10.6 Testing for the Circumvention of Work Flows</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse">
+<li class="wstg-nav-item" data-title="4.10.7 Test Defenses Against Application Misuse" data-hints="wstg-busl-07 busl-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/07-Test_Defenses_Against_Application_Misuse" title="4.10.7 Test Defenses Against Application Misuse">4.10.7 Test Defenses Against Application Misuse</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types">
+<li class="wstg-nav-item" data-title="4.10.8 Test Upload of Unexpected File Types" data-hints="wstg-busl-08 busl-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/08-Test_Upload_of_Unexpected_File_Types" title="4.10.8 Test Upload of Unexpected File Types">4.10.8 Test Upload of Unexpected File Types</a>
 </li>
-<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files">
+<li class="wstg-nav-item" data-title="4.10.9 Test Upload of Malicious Files" data-hints="wstg-busl-09 busl-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" data-nav-url="4-Web_Application_Security_Testing/10-Business_Logic_Testing/09-Test_Upload_of_Malicious_Files" title="4.10.9 Test Upload of Malicious Files">4.10.9 Test Upload of Malicious Files</a>
 </li>
 </ul>
@@ -527,43 +527,43 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting">
+<li class="wstg-nav-item" data-title="4.11.1 Testing for DOM-Based Cross Site Scripting" data-hints="xss dom xss domxss wstg-clnt-01 clnt-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/01-Testing_for_DOM-based_Cross_Site_Scripting" title="4.11.1 Testing for DOM-Based Cross Site Scripting">4.11.1 Testing for DOM-Based Cross Site Scripting</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution">
+<li class="wstg-nav-item" data-title="4.11.2 Testing for JavaScript Execution" data-hints="wstg-clnt-02 clnt-02">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/02-Testing_for_JavaScript_Execution" title="4.11.2 Testing for JavaScript Execution">4.11.2 Testing for JavaScript Execution</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection">
+<li class="wstg-nav-item" data-title="4.11.3 Testing for HTML Injection" data-hints="wstg-clnt-03 clnt-03">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/03-Testing_for_HTML_Injection" title="4.11.3 Testing for HTML Injection">4.11.3 Testing for HTML Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.4 Testing for Client-side URL Redirect">
+<li class="wstg-nav-item" data-title="4.11.4 Testing for Client-side URL Redirect" data-hints="open redirect wstg-clnt-04 clnt-04">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/04-Testing_for_Client-side_URL_Redirect" title="4.11.4 Testing for Client-side URL Redirect">4.11.4 Testing for Client-side URL Redirect</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection">
+<li class="wstg-nav-item" data-title="4.11.5 Testing for CSS Injection" data-hints="wstg-clnt-05 clnt-05">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/05-Testing_for_CSS_Injection" title="4.11.5 Testing for CSS Injection">4.11.5 Testing for CSS Injection</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.6 Testing for Client-side Resource Manipulation">
+<li class="wstg-nav-item" data-title="4.11.6 Testing for Client-side Resource Manipulation" data-hints="wstg-clnt-06 clnt-06">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/06-Testing_for_Client-side_Resource_Manipulation" title="4.11.6 Testing for Client-side Resource Manipulation">4.11.6 Testing for Client-side Resource Manipulation</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing">
+<li class="wstg-nav-item" data-title="4.11.7 Testing Cross Origin Resource Sharing" data-hints="cors headers wstg-clnt-07 clnt-07">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing" title="4.11.7 Testing Cross Origin Resource Sharing">4.11.7 Testing Cross Origin Resource Sharing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing">
+<li class="wstg-nav-item" data-title="4.11.8 Testing for Cross Site Flashing" data-hints="wstg-clnt-08 clnt-08">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/08-Testing_for_Cross_Site_Flashing" title="4.11.8 Testing for Cross Site Flashing">4.11.8 Testing for Cross Site Flashing</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking">
+<li class="wstg-nav-item" data-title="4.11.9 Testing for Clickjacking" data-hints="ui redress ui redressing x-frame-options framing wstg-clnt-09 clnt-09">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking" title="4.11.9 Testing for Clickjacking">4.11.9 Testing for Clickjacking</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets">
+<li class="wstg-nav-item" data-title="4.11.10 Testing WebSockets" data-hints="ws wstg-clnt-10 clnt-10">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets" title="4.11.10 Testing WebSockets">4.11.10 Testing WebSockets</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging">
+<li class="wstg-nav-item" data-title="4.11.11 Testing Web Messaging" data-hints="postmessage post message wstg-clnt-11 clnt-11">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/11-Testing_Web_Messaging" title="4.11.11 Testing Web Messaging">4.11.11 Testing Web Messaging</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage">
+<li class="wstg-nav-item" data-title="4.11.12 Testing Browser Storage" data-hints="localstorage sessionstorage wstg-clnt-12 clnt-12">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/12-Testing_Browser_Storage" title="4.11.12 Testing Browser Storage">4.11.12 Testing Browser Storage</a>
 </li>
-<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion">
+<li class="wstg-nav-item" data-title="4.11.13 Testing for Cross Site Script Inclusion" data-hints="xssi wstg-clnt-13 clnt-13">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" data-nav-url="4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion" title="4.11.13 Testing for Cross Site Script Inclusion">4.11.13 Testing for Cross Site Script Inclusion</a>
 </li>
 </ul>
@@ -578,7 +578,7 @@
 </span>
 </summary>
 <ul>
-<li class="wstg-nav-item" data-title="4.12.1 Testing GraphQL">
+<li class="wstg-nav-item" data-title="4.12.1 Testing GraphQL" data-hints="gql wstg-apit-01 apit-01">
 <a href="{{ site.baseurl }}/v42/4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL" data-nav-url="4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL" title="4.12.1 Testing GraphQL">4.12.1 Testing GraphQL</a>
 </li>
 </ul>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,7 +3,7 @@
 <nav class="wstg-nav" id="wstg-nav-{{ include.collection }}" aria-label="{{ nav.docs_list_title | default: 'WSTG Contents' | escape }}">
   <h2 class="wstg-nav-title"><a href="{{ site.baseurl }}/{{ include.collection }}/">{{ nav.docs_list_title }}</a></h2>
   <label class="visually-hidden" for="wstg-nav-filter-{{ include.collection }}">Filter contents</label>
-  <input id="wstg-nav-filter-{{ include.collection }}" class="wstg-nav-filter" type="search" placeholder="Filter (e.g. XSS, 4.7, OAuth)" autocomplete="off">
+  <input id="wstg-nav-filter-{{ include.collection }}" class="wstg-nav-filter" type="search" placeholder="Filter (XSS, sqli, WSTG-INPV-01, 4.7)" autocomplete="off">
   <div class="wstg-nav-controls">
     <button type="button" data-wstg-expand>Expand All</button>
     <button type="button" data-wstg-collapse>Collapse All</button>

--- a/assets/js/wstg-nav.js
+++ b/assets/js/wstg-nav.js
@@ -161,7 +161,8 @@
     var ordered = [];
     for (i = 0; i < items.length; i++) {
       var title = (items[i].getAttribute("data-title") || "").toLowerCase();
-      items[i]._wstgSelfMatch = title.indexOf(query) !== -1;
+      var hints = (items[i].getAttribute("data-hints") || "").toLowerCase();
+      items[i]._wstgSelfMatch = (title + " " + hints).indexOf(query) !== -1;
       ordered.push(items[i]);
     }
 


### PR DESCRIPTION
## Summary
- Filter matches `data-title` and `data-hints` (aliases + WSTG IDs)
- Regenerate nav trees / `_data` YAML with hints
- Placeholder examples include XSS, sqli, WSTG-INPV-01

Companion generator PR: https://github.com/OWASP/wstg/pull/1456